### PR TITLE
Add frequency set generator of homogeneous user activities within a publisher.

### DIFF
--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -26,6 +26,7 @@ import numpy as np
 
 from wfa_cardinality_estimation_evaluation_framework.common.analysis import relative_error
 from wfa_cardinality_estimation_evaluation_framework.common.random import choice_fast
+
 ORDER_ORIGINAL = 'original'
 ORDER_REVERSED = 'reversed'
 ORDER_RANDOM = 'random'
@@ -593,5 +594,6 @@ class HomogeneousMultiSetGenerator(SetGeneratorBase):
       multiset_ids = []
       for i, freq in zip(set_ids, freq_per_id):
         multiset_ids += [i] * freq
+      self.random_state.shuffle(multiset_ids)
       yield multiset_ids
     return self

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -433,8 +433,8 @@ class SetGeneratorTest(parameterized.TestCase):
           shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
 
   @parameterized.parameters(
-      (None, [[0, 0, 0, 0, 0, 0], [0, 0, 1, 1]]),
-      (3, [[0, 0, 0], [0, 0, 1, 1]]))
+      (None, [[0, 0, 0, 0, 0, 0], [1, 1, 0, 0]]),
+      (3, [[0, 0, 0], [1, 1, 0, 0]]))
   def test_homogeneous_multiset_generator_freq_cap(
       self, freq_cap, expected_multiset_ids_list):
     set_sizes = [1, 2]
@@ -444,9 +444,8 @@ class SetGeneratorTest(parameterized.TestCase):
         universe_size=4,
         set_sizes=set_sizes,
         freq_rate_list=freq_rate_list,
-        freq_cap=3,
+        freq_cap=freq_cap,
         random_state=rs)
-    expected_multiset_ids_list = [[0, 0, 0], [1, 1, 0, 0]]
     with mock.patch.object(gen, 'choice', autospec=True) as mock_choice:
       mock_choice.side_effect = fake_choice_fast
       output_multiset_ids_list = [multiset_ids for multiset_ids in gen]

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -74,7 +74,7 @@ class SetGeneratorTest(parameterized.TestCase):
     Args:
       set_generator_class: class name of different set_generators.
       kwargs: kwargs expect universe_size, set_size_list and random_state, in
-        each set_generator. In this test, universe_size and set_size_list are
+        each set_generator. In this test, universe_size and set_sizes are
         given by the global variables TEST_UNIVERSE_SIZE and TEST_SET_SIZE_LIST.
     """
     factory = set_generator_class.get_generator_factory_with_num_and_size(
@@ -82,7 +82,7 @@ class SetGeneratorTest(parameterized.TestCase):
         set_size=TEST_SET_SIZE, **kwargs)
     gen_from_factory = factory(np.random.RandomState(1))
     gen_from_class = set_generator_class(
-        universe_size=TEST_UNIVERSE_SIZE, set_size_list=TEST_SET_SIZE_LIST,
+        universe_size=TEST_UNIVERSE_SIZE, set_sizes=TEST_SET_SIZE_LIST,
         **kwargs, random_state=np.random.RandomState(1))
     set_list_gen_from_factory = []
     for ids in gen_from_factory:
@@ -151,7 +151,7 @@ class SetGeneratorTest(parameterized.TestCase):
         **kwargs)
     gen_from_factory = factory(np.random.RandomState(1))
     gen_from_class = set_generator_class(
-        universe_size=TEST_UNIVERSE_SIZE, set_size_list=TEST_SET_SIZE_LIST,
+        universe_size=TEST_UNIVERSE_SIZE, set_sizes=TEST_SET_SIZE_LIST,
         **kwargs, random_state=np.random.RandomState(1))
     set_list_gen_from_factory = []
     for ids in gen_from_factory:
@@ -164,14 +164,14 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_independent_generator_constructor(self):
     rs = np.random.RandomState(1)
     ind_gen = set_generator.IndependentSetGenerator(
-        universe_size=10000, set_size_list=[100] * 5, random_state=rs)
+        universe_size=10000, set_sizes=[100] * 5, random_state=rs)
     for campaign_id in ind_gen:
       self.assertLen(campaign_id, 100)
 
   def test_independent_generator_constructor_different_sizes(self):
     rs = np.random.RandomState(1)
     ind_gen = set_generator.IndependentSetGenerator(
-        universe_size=10000, set_size_list=[10, 10, 10, 20, 20],
+        universe_size=10000, set_sizes=[10, 10, 10, 20, 20],
         random_state=rs)
     set_ids_list = []
     for set_ids in ind_gen:
@@ -184,7 +184,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_independent_generator_single_universe(self):
     rs = np.random.RandomState(1)
     ind_gen = set_generator.IndependentSetGenerator(
-        universe_size=1, set_size_list=[1], random_state=rs)
+        universe_size=1, set_sizes=[1], random_state=rs)
     for campaign_id in ind_gen:
       self.assertLen(campaign_id, 1)
       self.assertEqual(campaign_id[0], 0)
@@ -194,7 +194,7 @@ class SetGeneratorTest(parameterized.TestCase):
     # Low reach case, actual set size should be close to input set size
     eb_gen = set_generator.ExponentialBowSetGenerator(
         user_activity_association='independent',
-        universe_size=10000, set_size_list=[1000] * 5, random_state=rs)
+        universe_size=10000, set_sizes=[1000] * 5, random_state=rs)
     for set_ids in eb_gen:
       re = relative_error(len(set_ids), 1000)
       self.assertLess(abs(re), 0.01,
@@ -202,7 +202,7 @@ class SetGeneratorTest(parameterized.TestCase):
     # High reach case, allow actual size to be more different from input size
     eb_gen = set_generator.ExponentialBowSetGenerator(
         user_activity_association='independent',
-        universe_size=10000, set_size_list=[5000] * 5, random_state=rs)
+        universe_size=10000, set_sizes=[5000] * 5, random_state=rs)
     for set_ids in eb_gen:
       re = relative_error(len(set_ids), 5000)
       self.assertLess(abs(re), 0.2,
@@ -214,7 +214,7 @@ class SetGeneratorTest(parameterized.TestCase):
     low_set_size_list = [600, 800, 1000]
     eb_gen = set_generator.ExponentialBowSetGenerator(
         user_activity_association='independent',
-        universe_size=10000, set_size_list=low_set_size_list, random_state=rs)
+        universe_size=10000, set_sizes=low_set_size_list, random_state=rs)
     actual_set_size = iter(low_set_size_list)
     for set_ids in eb_gen:
       re = relative_error(len(set_ids), next(actual_set_size))
@@ -224,7 +224,7 @@ class SetGeneratorTest(parameterized.TestCase):
     high_set_size_list = [4000, 5000, 6000]
     eb_gen = set_generator.ExponentialBowSetGenerator(
         user_activity_association='independent',
-        universe_size=10000, set_size_list=high_set_size_list, random_state=rs)
+        universe_size=10000, set_sizes=high_set_size_list, random_state=rs)
     actual_set_size = iter(high_set_size_list)
     for set_ids in eb_gen:
       re = relative_error(len(set_ids), next(actual_set_size))
@@ -237,12 +237,12 @@ class SetGeneratorTest(parameterized.TestCase):
     with self.assertRaises(ValueError):
       _ = set_generator.ExponentialBowSetGenerator(
           user_activity_association=0.5,
-          universe_size=10000, set_size_list=[1000] * 3, random_state=rs)
+          universe_size=10000, set_sizes=[1000] * 3, random_state=rs)
     # Two small set size
     with self.assertRaises(ValueError):
       _ = set_generator.ExponentialBowSetGenerator(
           user_activity_association='independent',
-          universe_size=10000, set_size_list=[10] * 3, random_state=rs)
+          universe_size=10000, set_sizes=[10] * 3, random_state=rs)
 
   def test_fully_overlap_generator_constructor(self):
     rs = np.random.RandomState(1)
@@ -357,7 +357,7 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='original', correlated_sets='all', universe_size=30,
-        shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+        shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
     for set_ids in set_ids_list[1:]:
@@ -369,7 +369,7 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='original', correlated_sets='all', universe_size=100,
-        shared_prop=0.2, set_size_list=[10, 15, 20, 20], random_state=rs)
+        shared_prop=0.2, set_sizes=[10, 15, 20, 20], random_state=rs)
     expected_overlap_size = iter([2, 3, 4])
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
@@ -382,7 +382,7 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='reversed', correlated_sets='all', universe_size=30,
-        shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+        shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen][::-1]
     previous_set_ids = set(set_ids_list[0])
     for set_ids in set_ids_list[1:]:
@@ -394,7 +394,7 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='original', correlated_sets='one', universe_size=30,
-        shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+        shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
     union_set_ids = set(set_ids_list[0])
@@ -408,7 +408,7 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='reversed', correlated_sets='one', universe_size=30,
-        shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+        shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen][::-1]
     previous_set_ids = set(set_ids_list[0])
     union_set_ids = set(set_ids_list[0])
@@ -423,23 +423,23 @@ class SetGeneratorTest(parameterized.TestCase):
     with self.assertRaises(ValueError):
       _ = set_generator.SequentiallyCorrelatedSetGenerator(
           order='not_implemented', correlated_sets='all', universe_size=30,
-          shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+          shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     with self.assertRaises(ValueError):
       _ = set_generator.SequentiallyCorrelatedSetGenerator(
           order='random', correlated_sets='not_implemented', universe_size=30,
-          shared_prop=0.2, set_size_list=[10] * 3, random_state=rs)
+          shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
 
   @parameterized.parameters(
       (None, [[0, 0, 0, 0, 0, 0], [0, 0, 1, 1]]),
       (3, [[0, 0, 0], [0, 0, 1, 1]]))
   def test_homogeneous_multiset_generator_freq_cap(
       self, freq_cap, expected_multiset_ids_list):
-    set_size_list = [1, 2]
+    set_sizes = [1, 2]
     freq_rate_list = [5, 1]
     rs = FakeRandomState()
     gen = set_generator.HomogeneousMultiSetGenerator(
         universe_size=4,
-        set_size_list=set_size_list,
+        set_sizes=set_sizes,
         freq_rate_list=freq_rate_list,
         freq_cap=3,
         random_state=rs)
@@ -454,12 +454,12 @@ class SetGeneratorTest(parameterized.TestCase):
           f'{freq_cap}.')
 
   def test_homogeneous_multiset_generator_raise_unequal_length_input(self):
-    # Test if raise error when set_size_list and freq_rate_list do not have
+    # Test if raise error when set_sizes and freq_rate_list do not have
     # equal length.
     with self.assertRaises(AssertionError):
       _ = set_generator.HomogeneousMultiSetGenerator(
           universe_size=4,
-          set_size_list=[1, 1],
+          set_sizes=[1, 1],
           freq_rate_list=[1],
           freq_cap=3,
           random_state=np.random.RandomState())
@@ -469,7 +469,7 @@ class SetGeneratorTest(parameterized.TestCase):
     with self.assertRaises(AssertionError):
       _ = set_generator.HomogeneousMultiSetGenerator(
           universe_size=4,
-          set_size_list=[1, 1],
+          set_sizes=[1, 1],
           freq_rate_list=[-1, 1],
           freq_cap=3,
           random_state=np.random.RandomState())
@@ -481,7 +481,7 @@ class SetGeneratorTest(parameterized.TestCase):
     with self.assertRaises(AssertionError):
       _ = set_generator.HomogeneousMultiSetGenerator(
           universe_size=4,
-          set_size_list=[1, 1],
+          set_sizes=[1, 1],
           freq_rate_list=[1, 1],
           freq_cap=freq_cap,
           random_state=np.random.RandomState())

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -39,6 +39,9 @@ class FakeRandomState:
   def poisson(self, lam, size):
     return lam * np.ones(size, dtype=int)
 
+  def shuffle(self, l):
+    l.reverse()
+
 
 class SetGeneratorTest(parameterized.TestCase):
 
@@ -443,7 +446,7 @@ class SetGeneratorTest(parameterized.TestCase):
         freq_rate_list=freq_rate_list,
         freq_cap=3,
         random_state=rs)
-    expected_multiset_ids_list = [[0, 0, 0], [0, 0, 1, 1]]
+    expected_multiset_ids_list = [[0, 0, 0], [1, 1, 0, 0]]
     with mock.patch.object(gen, 'choice', autospec=True) as mock_choice:
       mock_choice.side_effect = fake_choice_fast
       output_multiset_ids_list = [multiset_ids for multiset_ids in gen]


### PR DESCRIPTION
The scenario assumes that the users within a publisher’s campaign have the same uniform Poisson frequency distribution. Also frequency capping is supported.