### PR TITLE
run_tests.py should throw errors if modules are not importable.

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -66,21 +66,16 @@ def find_modules(folders):
         return '.'.join(split)
 
     test_modules = map(file_name_to_module_name, test_files)
+    # Filter out python modules from virtual environments
+    filter_func = lambda module_name: "lib.python" not in module_name \
+                                  and "lib64.python" not in module_name
+    test_modules = filter(filter_func, test_modules)
+
 
     modules = []
     # Import modules and filter out ones that cannot be imported.
     for module_name in test_modules:
-        try:
-            module = import_module(module_name)
-        except ModuleNotFoundError as e:
-            # The most common type of error we get is that the virtual 
-            # environment is in the top-level directory. We don't want 
-            # to run those tests. In the case that the ModuleNotFoundError 
-            # is not from attempting to import python libraries, we should
-            # fail this process and print the error message.
-            if "lib.python" not in module_name and "lib64.python" not in module_name:
-                exit(e)
-            continue
+        module = import_module(module_name)
         modules.append((module_name, module))
 
     return modules

--- a/run_tests.py
+++ b/run_tests.py
@@ -72,7 +72,14 @@ def find_modules(folders):
     for module_name in test_modules:
         try:
             module = import_module(module_name)
-        except:
+        except ModuleNotFoundError as e:
+            # The most common type of error we get is that the virtual 
+            # environment is in the top-level directory. We don't want 
+            # to run those tests. In the case that the ModuleNotFoundError 
+            # is not from attempting to import python libraries, we should
+            # fail this process and print the error message.
+            if "lib.python" not in module_name and "lib64.python" not in module_name:
+                exit(e)
             continue
         modules.append((module_name, module))
 

--- a/src/evaluations/analyzer.py
+++ b/src/evaluations/analyzer.py
@@ -62,7 +62,7 @@ KEY_RUNNING_TIME_DF = 'running_time_df'
 
 
 def get_num_estimable_sets(df, num_sets=simulator.NUM_SETS,
-                           relative_error=simulator.RELATIVE_ERROR_BASENAME,
+                           relative_error=simulator.RELATIVE_ERROR,
                            error_margin=ERROR_MARGIN,
                            proportion_of_runs=PROPORTION_OF_RUNS):
   """Get the number of estimable sets.
@@ -202,7 +202,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
       df = self.raw_df.groupby([SKETCH_ESTIMATOR_NAME, SCENARIO_NAME]).apply(
           _get_num_estimable_sets_series,
           num_sets=simulator.NUM_SETS,
-          relative_error=simulator.RELATIVE_ERROR_BASENAME,
+          relative_error=simulator.RELATIVE_ERROR,
           error_margin=criteria[0],
           proportion_of_runs=criteria[1]).reset_index()
       df[ERROR_MARGIN_NAME] = criteria[0]
@@ -223,7 +223,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
         df.groupby([
             ERROR_MARGIN_NAME, PROPORTION_OF_RUNS_NAME, SKETCH_ESTIMATOR_NAME,
             SCENARIO_NAME, NUM_ESTIMABLE_SETS])
-        .agg({simulator.RELATIVE_ERROR_BASENAME: ['mean', 'std']}))
+        .agg({simulator.RELATIVE_ERROR: ['mean', 'std']}))
     result.columns = result.columns.map('_'.join)
     result = result.reset_index()
     return result
@@ -234,7 +234,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
       ax = plotting.boxplot_relative_error(
           df,
           num_sets=simulator.NUM_SETS,
-          relative_error=simulator.RELATIVE_ERROR_BASENAME)
+          relative_error=simulator.RELATIVE_ERROR)
       scenario_name = df[SCENARIO_NAME].values[0]
       estimator_name = df[SKETCH_ESTIMATOR_NAME].values[0]
       ax.set_title(f'{scenario_name}\n{estimator_name}')

--- a/src/evaluations/analyzer.py
+++ b/src/evaluations/analyzer.py
@@ -62,7 +62,7 @@ KEY_RUNNING_TIME_DF = 'running_time_df'
 
 
 def get_num_estimable_sets(df, num_sets=simulator.NUM_SETS,
-                           relative_error=simulator.RELATIVE_ERROR,
+                           relative_error=simulator.RELATIVE_ERROR_BASENAME,
                            error_margin=ERROR_MARGIN,
                            proportion_of_runs=PROPORTION_OF_RUNS):
   """Get the number of estimable sets.
@@ -202,7 +202,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
       df = self.raw_df.groupby([SKETCH_ESTIMATOR_NAME, SCENARIO_NAME]).apply(
           _get_num_estimable_sets_series,
           num_sets=simulator.NUM_SETS,
-          relative_error=simulator.RELATIVE_ERROR,
+          relative_error=simulator.RELATIVE_ERROR_BASENAME,
           error_margin=criteria[0],
           proportion_of_runs=criteria[1]).reset_index()
       df[ERROR_MARGIN_NAME] = criteria[0]
@@ -223,7 +223,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
         df.groupby([
             ERROR_MARGIN_NAME, PROPORTION_OF_RUNS_NAME, SKETCH_ESTIMATOR_NAME,
             SCENARIO_NAME, NUM_ESTIMABLE_SETS])
-        .agg({simulator.RELATIVE_ERROR: ['mean', 'std']}))
+        .agg({simulator.RELATIVE_ERROR_BASENAME: ['mean', 'std']}))
     result.columns = result.columns.map('_'.join)
     result = result.reset_index()
     return result
@@ -234,7 +234,7 @@ class CardinalityEstimatorEvaluationAnalyzer(object):
       ax = plotting.boxplot_relative_error(
           df,
           num_sets=simulator.NUM_SETS,
-          relative_error=simulator.RELATIVE_ERROR)
+          relative_error=simulator.RELATIVE_ERROR_BASENAME)
       scenario_name = df[SCENARIO_NAME].values[0]
       estimator_name = df[SKETCH_ESTIMATOR_NAME].values[0]
       ax.set_title(f'{scenario_name}\n{estimator_name}')


### PR DESCRIPTION
Previous behavior allowed modules to silently fail to import. This implementation still allows for in-directory virtual environments, but throws errors when project modules do not import.