### PR TITLE
Modify the complete evaluation configs and add additional tests.

### DIFF
--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -352,26 +352,22 @@ def _complete_test_with_selected_parameters(
   large_set_size = int(large_set_size_rate * universe_size)
 
   # Scenario 3 (b). Exponential bow, identical user behavior.
-  scenario_config_list.append(
-      _generate_configs_scenario_3b(
-          universe_size, num_sets, small_set_size, large_set_size,
-          user_activity_assciation))
+  scenario_config_list += _generate_configs_scenario_3b(
+      universe_size, num_sets, small_set_size, large_set_size,
+      user_activity_assciation)
 
   # Scenario 4(a). Fully-overlapped.
-  scenario_config_list.append(
-      _generate_configs_scenario_4a(
-          universe_size, num_sets, small_set_size, large_set_size))
+  scenario_config_list += _generate_configs_scenario_4a(
+      universe_size, num_sets, small_set_size, large_set_size)
 
   # Scenario 4(b). Subset campaigns.
-  scenario_config_list.append(
-      _generate_configs_scenario_4b(
-          universe_size, num_sets, small_set_size, large_set_size, order))
+  scenario_config_list += _generate_configs_scenario_4b(
+      universe_size, num_sets, small_set_size, large_set_size, order)
 
   # Scenario 5. Sequentially correlated campaigns
-  scenario_config_list.append(
-      _generate_configs_scenario_5(
-          universe_size, num_sets, small_set_size, large_set_size, order,
-          shared_prop_list))
+  scenario_config_list += _generate_configs_scenario_5(
+      universe_size, num_sets, small_set_size, large_set_size, order,
+      shared_prop_list)
 
   return EvaluationConfig(
       name='complete_test_with_selected_parameters',

--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -17,11 +17,17 @@ from absl.testing import absltest
 
 import numpy as np
 
+from wfa_cardinality_estimation_evaluation_framework.evaluations import configs
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data import evaluation_configs
+from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import _complete_test_with_selected_parameters
 from wfa_cardinality_estimation_evaluation_framework.simulations import set_generator
 
 
 class EvaluationConfigTest(absltest.TestCase):
+
+  EVALUATION_CONFIGS_MODULE = (
+      'wfa_cardinality_estimation_evaluation_framework.evaluations.data.'
+      + 'evaluation_configs.')
 
   def test_generate_configs_scenario_3b_set_sizes_correct(self):
     conf_list = evaluation_configs._generate_configs_scenario_3b(
@@ -196,10 +202,10 @@ class EvaluationConfigTest(absltest.TestCase):
 
     self.assertEqual(result, expected)
 
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_3b')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_4a')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_4b')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_5')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_3b')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_4a')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_4b')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_5')
   def test_complete_test_with_selected_parameters_all_scenario_used(
       self,
       scenario_config_3b,
@@ -207,11 +213,17 @@ class EvaluationConfigTest(absltest.TestCase):
       scenario_config_4b,
       scenario_config_5):
     """Test all the scenarios are concluded in the complete test."""
-    _ = evaluation_configs._complete_test_with_selected_parameters()
+    _ = _complete_test_with_selected_parameters(num_runs=1)
     self.assertTrue(scenario_config_3b.called, 'Scenario 3b not included.')
     self.assertTrue(scenario_config_4a.called, 'Scenario 4a not included.')
     self.assertTrue(scenario_config_4b.called, 'Scenario 4b not included.')
     self.assertTrue(scenario_config_5.called, 'Scenario 5 not included.')
+
+  def test_complete_test_with_selected_parameters_contains_scenario_configs(
+      self):
+    eval_configs = _complete_test_with_selected_parameters(num_runs=1)
+    for scenario_config in eval_configs.scenario_config_list:
+      self.assertIsInstance(scenario_config, configs.ScenarioConfig)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
1. Correct the complete evaluation function, so it should contain a list of scenario configs.
2. Add unit test for 1.
3. Modify the mock patch for testing if the complete evaluation function uses all the scenarios. Now it should work with both
(1) python run_tests.py --folders=src/evaluations/data/
(2) python src/evaluations/data/tests/evaluation_configs_test.py
The previous PR only works with (2).