### PR TITLE
Fix sequentially correlated set generator.

### DIFF
--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -352,26 +352,22 @@ def _complete_test_with_selected_parameters(
   large_set_size = int(large_set_size_rate * universe_size)
 
   # Scenario 3 (b). Exponential bow, identical user behavior.
-  scenario_config_list.append(
-      _generate_configs_scenario_3b(
-          universe_size, num_sets, small_set_size, large_set_size,
-          user_activity_assciation))
+  scenario_config_list += _generate_configs_scenario_3b(
+      universe_size, num_sets, small_set_size, large_set_size,
+      user_activity_assciation)
 
   # Scenario 4(a). Fully-overlapped.
-  scenario_config_list.append(
-      _generate_configs_scenario_4a(
-          universe_size, num_sets, small_set_size, large_set_size))
+  scenario_config_list += _generate_configs_scenario_4a(
+      universe_size, num_sets, small_set_size, large_set_size)
 
   # Scenario 4(b). Subset campaigns.
-  scenario_config_list.append(
-      _generate_configs_scenario_4b(
-          universe_size, num_sets, small_set_size, large_set_size, order))
+  scenario_config_list += _generate_configs_scenario_4b(
+      universe_size, num_sets, small_set_size, large_set_size, order)
 
   # Scenario 5. Sequentially correlated campaigns
-  scenario_config_list.append(
-      _generate_configs_scenario_5(
-          universe_size, num_sets, small_set_size, large_set_size, order,
-          shared_prop_list))
+  scenario_config_list += _generate_configs_scenario_5(
+      universe_size, num_sets, small_set_size, large_set_size, order,
+      shared_prop_list)
 
   return EvaluationConfig(
       name='complete_test_with_selected_parameters',

--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -81,7 +81,7 @@ def _smoke_test(num_runs=NUM_RUNS_VALUE):
                   .get_generator_factory_with_num_and_size(
                       order=set_generator.ORDER_ORIGINAL,
                       correlated_sets=set_generator.CORRELATED_SETS_ALL,
-                      universe_size=3 * 10**8, num_sets=20, set_size=10000,
+                      num_sets=20, set_size=10000,
                       shared_prop=0.5))),
           ScenarioConfig(
               name='sequentially_correlated_one',
@@ -90,7 +90,7 @@ def _smoke_test(num_runs=NUM_RUNS_VALUE):
                   .get_generator_factory_with_num_and_size(
                       order=set_generator.ORDER_ORIGINAL,
                       correlated_sets=set_generator.CORRELATED_SETS_ONE,
-                      universe_size=3 * 10**8, num_sets=20, set_size=10000,
+                      num_sets=20, set_size=10000,
                       shared_prop=0.5))),
           )
       )
@@ -242,7 +242,7 @@ def _generate_configs_scenario_4b(universe_size, num_sets, small_set_size,
   return scenario_config_list
 
 
-def _generate_configs_scenario_5(universe_size, num_sets, small_set_size,
+def _generate_configs_scenario_5(num_sets, small_set_size,
                                  large_set_size, order, shared_prop_list):
   """Generate configs of Scenario 5.
 
@@ -252,7 +252,6 @@ def _generate_configs_scenario_5(universe_size, num_sets, small_set_size,
   https://github.com/world-federation-of-advertisers/cardinality_estimation_evaluation_framework/blob/master/doc/cardinality_and_frequency_estimation_evaluation_framework.md#scenario-5-sequentially-correlated-campaigns
 
   Args:
-    universe_size: the size of the pools from which the IDs will be selected.
     num_sets: the number of sets.
     small_set_size: the reach of the small reach sets.
     large_set_size: the reach of the large reach sets.
@@ -298,7 +297,6 @@ def _generate_configs_scenario_5(universe_size, num_sets, small_set_size,
             ScenarioConfig(
                 name='-'.join([
                     'sequentially_correlated',
-                    'universe_size:' + str(universe_size),
                     'order:' + str(order),
                     'correlated_sets:' + str(correlated_sets),
                     'shared_prop:' + str(shared_prop),
@@ -311,7 +309,6 @@ def _generate_configs_scenario_5(universe_size, num_sets, small_set_size,
                     get_generator_factory_with_set_size_list(
                         order=order,
                         correlated_sets=correlated_sets,
-                        universe_size=universe_size,
                         shared_prop=shared_prop,
                         set_size_list=set_size_list)))
         )
@@ -366,7 +363,7 @@ def _complete_test_with_selected_parameters(
 
   # Scenario 5. Sequentially correlated campaigns
   scenario_config_list += _generate_configs_scenario_5(
-      universe_size, num_sets, small_set_size, large_set_size, order,
+      num_sets, small_set_size, large_set_size, order,
       shared_prop_list)
 
   return EvaluationConfig(

--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -112,7 +112,6 @@ class EvaluationConfigTest(absltest.TestCase):
 
   def test_generate_configs_scenario_5(self):
     conf_list = evaluation_configs._generate_configs_scenario_5(
-        universe_size=100,
         num_sets=3,
         small_set_size=2,
         large_set_size=8,
@@ -126,75 +125,75 @@ class EvaluationConfigTest(absltest.TestCase):
       result[conf.name] = [len(set_ids) for set_ids in gen]
 
     expected = {
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:1st_half_large_2nd_half_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:1st_half_small_2nd_half_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:1st_large_then_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:1st_small_then_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:all_large_except_middle_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:all_small_except_middle_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:large_then_last_small-'
         'large_set_size:8-small_set_size:2': [8, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:repeated_small_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:all-shared_prop:0.1-'
         'set_type:small_then_last_large-'
         'large_set_size:8-small_set_size:2': [2, 2, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:1st_half_large_2nd_half_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:1st_half_small_2nd_half_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:1st_large_then_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:1st_small_then_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:all_large_except_middle_small-'
         'large_set_size:8-small_set_size:2': [8, 2, 8],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:all_small_except_middle_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:large_then_last_small-'
         'large_set_size:8-small_set_size:2': [8, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:repeated_small_large-'
         'large_set_size:8-small_set_size:2': [2, 8, 2],
-        'sequentially_correlated-universe_size:100-order:original-'
+        'sequentially_correlated-order:original-'
         'correlated_sets:one-shared_prop:0.1-'
         'set_type:small_then_last_large-'
         'large_set_size:8-small_set_size:2': [2, 2, 8]

--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -17,11 +17,17 @@ from absl.testing import absltest
 
 import numpy as np
 
+from wfa_cardinality_estimation_evaluation_framework.evaluations import configs
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data import evaluation_configs
+from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import _complete_test_with_selected_parameters
 from wfa_cardinality_estimation_evaluation_framework.simulations import set_generator
 
 
 class EvaluationConfigTest(absltest.TestCase):
+
+  EVALUATION_CONFIGS_MODULE = (
+      'wfa_cardinality_estimation_evaluation_framework.evaluations.data.'
+      + 'evaluation_configs.')
 
   def test_generate_configs_scenario_3b_set_sizes_correct(self):
     conf_list = evaluation_configs._generate_configs_scenario_3b(
@@ -196,10 +202,10 @@ class EvaluationConfigTest(absltest.TestCase):
 
     self.assertEqual(result, expected)
 
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_3b')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_4a')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_4b')
-  @mock.patch('__main__.evaluation_configs._generate_configs_scenario_5')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_3b')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_4a')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_4b')
+  @mock.patch(EVALUATION_CONFIGS_MODULE + '_generate_configs_scenario_5')
   def test_complete_test_with_selected_parameters_all_scenario_used(
       self,
       scenario_config_3b,
@@ -207,11 +213,17 @@ class EvaluationConfigTest(absltest.TestCase):
       scenario_config_4b,
       scenario_config_5):
     """Test all the scenarios are concluded in the complete test."""
-    _ = evaluation_configs._complete_test_with_selected_parameters()
+    _ = _complete_test_with_selected_parameters(num_runs=1)
     self.assertTrue(scenario_config_3b.called, 'Scenario 3b not included.')
     self.assertTrue(scenario_config_4a.called, 'Scenario 4a not included.')
     self.assertTrue(scenario_config_4b.called, 'Scenario 4b not included.')
     self.assertTrue(scenario_config_5.called, 'Scenario 5 not included.')
+
+  def test_complete_test_with_selected_parameters_contains_scenario_configs(
+      self):
+    eval_configs = _complete_test_with_selected_parameters(num_runs=1)
+    for scenario_config in eval_configs.scenario_config_list:
+      self.assertIsInstance(scenario_config, configs.ScenarioConfig)
 
 
 if __name__ == '__main__':

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -397,13 +397,13 @@ class _SequentiallyCorrelatedThePreviousSetGenerator(SetGeneratorBase):
 
     Every newly generated set has some overlap with THE previously generated
     set. The overlap is determined by the previous set size multiplied by the
-    shared proportion. If the shared proportion is too large, will cap it by
-    the current set size.
+    shared proportion. If the previous set is not large enough, then will the
+    overlap will use the previous set itself.
 
     Args:
       shared_prop: a number between 0 and 1, indicating the proportion of ids of
         the current set coming from the previously generated set. I.e.,
-        overlap size divided by the previous set size.
+        overlap size divided by the current set size.
       set_size_list: a list of the integer numbers representing the set size of
         the sets.
       random_state: a numpy.random.RandomState instance.
@@ -413,8 +413,9 @@ class _SequentiallyCorrelatedThePreviousSetGenerator(SetGeneratorBase):
     self.set_size_list = set_size_list
     self.num_sets = len(set_size_list)
     # i-th element is the overlap size for the (i+1)-st set.
+    # If the previous set is not large enough, will use the previou set.
     self.overlap_size_list = [
-        min(int(set_size_list[i] * shared_prop), set_size_list[i + 1])
+        min(int(set_size_list[i + 1] * shared_prop), set_size_list[i])
         for i in range(self.num_sets - 1)]
     total_ids_size = int(sum(self.set_size_list) - sum(self.overlap_size_list))
     self.ids_pool = np.arange(total_ids_size)

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -402,7 +402,8 @@ class _SequentiallyCorrelatedThePreviousSetGenerator(SetGeneratorBase):
 
     Args:
       shared_prop: a number between 0 and 1, indicating the proportion of ids of
-        the current set coming from the union of the previously generated sets.
+        the current set coming from the previously generated set. I.e.,
+        overlap size divided by the previous set size.
       set_size_list: a list of the integer numbers representing the set size of
         the sets.
       random_state: a numpy.random.RandomState instance.

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -359,6 +359,8 @@ class _SequentiallyCorrelatedAllPreviousSetGenerator(SetGeneratorBase):
     self.num_sets = len(set_size_list)
     self.overlap_size_list = [0]
     # Find the actual size of the overlap and the total number of ids.
+    # The i-th element is the size of the IDs of the i-th set to be taken from
+    # the union of the previous sets.
     total_ids_size = set_size_list[0]
     for i in range(self.num_sets - 1):
       overlap_size = min(
@@ -396,9 +398,9 @@ class _SequentiallyCorrelatedThePreviousSetGenerator(SetGeneratorBase):
     """Construct a sequentially correlated set generator.
 
     Every newly generated set has some overlap with THE previously generated
-    set. The overlap is determined by the previous set size multiplied by the
-    shared proportion. If the previous set is not large enough, then will the
-    overlap will use the previous set itself.
+    set. The overlap is determined by the current set size multiplied by the
+    shared proportion. If the previous set is not large enough, will use the
+    previous set itself.
 
     Args:
       shared_prop: a number between 0 and 1, indicating the proportion of ids of

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -340,16 +340,30 @@ class _SequentiallyCorrelatedAllPreviousSetGenerator(SetGeneratorBase):
   """
 
   def __init__(self, shared_prop, set_size_list, random_state):
+    """Construct a sequentially correlated set generator.
+
+    Every newly generated set has some overlap with the union of the previous
+    sets. The overlap is determined by the set size multiplied by the shared
+    proportion. If the union is not large enough, will use the union itself.
+
+    Args:
+      shared_prop: a number between 0 and 1, indicating the proportion of ids of
+        the current set coming from the union of the previously generated sets.
+      set_size_list: a list of the integer numbers representing the set size of
+        the sets.
+      random_state: a numpy.random.RandomState instance.
+    """
     self.random_state = random_state
     self.union_ids = np.array([], dtype=int)
     self.set_size_list = set_size_list
     self.num_sets = len(set_size_list)
     self.overlap_size_list = [0]
+    # Find the actual size of the overlap and the total number of ids.
     total_ids_size = set_size_list[0]
     for i in range(self.num_sets - 1):
       overlap_size = min(
-          int(set_size_list[i] * shared_prop),
-          set_size_list[i + 1]
+          int(set_size_list[i + 1] * shared_prop),
+          total_ids_size
       )
       self.overlap_size_list.append(overlap_size)
       total_ids_size += set_size_list[i + 1] - overlap_size
@@ -379,6 +393,20 @@ class _SequentiallyCorrelatedThePreviousSetGenerator(SetGeneratorBase):
   """
 
   def __init__(self, shared_prop, set_size_list, random_state):
+    """Construct a sequentially correlated set generator.
+
+    Every newly generated set has some overlap with THE previously generated
+    set. The overlap is determined by the previous set size multiplied by the
+    shared proportion. If the shared proportion is too large, will cap it by
+    the current set size.
+
+    Args:
+      shared_prop: a number between 0 and 1, indicating the proportion of ids of
+        the current set coming from the union of the previously generated sets.
+      set_size_list: a list of the integer numbers representing the set size of
+        the sets.
+      random_state: a numpy.random.RandomState instance.
+    """
     self.random_state = random_state
     self.union_ids = np.array([], dtype=int)
     self.set_size_list = set_size_list

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -420,37 +420,26 @@ class SetGeneratorTest(parameterized.TestCase):
           shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
 
   @parameterized.parameters(
-      (set_generator.CORRELATED_SETS_ALL, 0),
-      (set_generator.CORRELATED_SETS_ONE, 1))
-  def test_sequentially_correlated_generator_overlap_size_larger_than_set_size(
-      self, correlation_type, expected_overlap_size):
+      (set_generator.CORRELATED_SETS_ALL,),
+      (set_generator.CORRELATED_SETS_ONE,))
+  def test_sequentially_correlated_generator_overlap_size_not_enough(
+      self, correlation_type):
     rs = np.random.RandomState(1)
+    set_sizes = [1, 10]
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order=set_generator.ORDER_ORIGINAL, correlated_sets=correlation_type,
-        shared_prop=0.5, set_sizes=[10, 1],
+        shared_prop=0.5,
+        set_sizes=set_sizes,
         random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
-    self.assertLen(set_ids_list[0], 10,
+    self.assertLen(set_ids_list[0], set_sizes[0],
                    f'{correlation_type}: First set size not correct.')
-    self.assertLen(set_ids_list[1], 1,
+    self.assertLen(set_ids_list[1], set_sizes[1],
                    f'{correlation_type}: Second set size not correct.')
     self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]),
-                   expected_overlap_size,
+                   1,
                    f'{correlation_type}: Overlap set size not correct.')
 
-  def test_sequentially_correlated_all_generator_overlap_size_not_enough(self):
-    rs = np.random.RandomState(2)
-    sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order=set_generator.ORDER_ORIGINAL,
-        correlated_sets=set_generator.CORRELATED_SETS_ALL,
-        shared_prop=0.5,
-        set_sizes=[1, 10],
-        random_state=rs)
-    set_ids_list = [set_ids for set_ids in sc_gen]
-    self.assertLen(set_ids_list[0], 1, 'First set size not correct.')
-    self.assertLen(set_ids_list[1], 10, 'Second set size not correct.')
-    self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]), 1,
-                   'Overlap set size not correct.')
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -360,7 +360,7 @@ class SetGeneratorTest(parameterized.TestCase):
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order='original', correlated_sets='all',
         shared_prop=0.2, set_sizes=[10, 15, 20, 20], random_state=rs)
-    expected_overlap_size = iter([2, 3, 4])
+    expected_overlap_size = iter([3, 4, 4])
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
     for set_ids in set_ids_list[1:]:
@@ -420,22 +420,37 @@ class SetGeneratorTest(parameterized.TestCase):
           shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
 
   @parameterized.parameters(
-      (set_generator.CORRELATED_SETS_ALL,),
-      (set_generator.CORRELATED_SETS_ONE,))
+      (set_generator.CORRELATED_SETS_ALL, 0),
+      (set_generator.CORRELATED_SETS_ONE, 1))
   def test_sequentially_correlated_generator_overlap_size_larger_than_set_size(
-      self, correlation_type):
+      self, correlation_type, expected_overlap_size):
+    rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
         order=set_generator.ORDER_ORIGINAL, correlated_sets=correlation_type,
         shared_prop=0.5, set_sizes=[10, 1],
-        random_state=np.random.RandomState())
+        random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
     self.assertLen(set_ids_list[0], 10,
                    f'{correlation_type}: First set size not correct.')
     self.assertLen(set_ids_list[1], 1,
                    f'{correlation_type}: Second set size not correct.')
-    self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]), 1,
+    self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]),
+                   expected_overlap_size,
                    f'{correlation_type}: Overlap set size not correct.')
 
+  def test_sequentially_correlated_all_generator_overlap_size_not_enough(self):
+    rs = np.random.RandomState(2)
+    sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
+        order=set_generator.ORDER_ORIGINAL,
+        correlated_sets=set_generator.CORRELATED_SETS_ALL,
+        shared_prop=0.5,
+        set_sizes=[1, 10],
+        random_state=rs)
+    set_ids_list = [set_ids for set_ids in sc_gen]
+    self.assertLen(set_ids_list[0], 1, 'First set size not correct.')
+    self.assertLen(set_ids_list[1], 10, 'Second set size not correct.')
+    self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]), 1,
+                   'Overlap set size not correct.')
 
 if __name__ == '__main__':
   absltest.main()

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -30,11 +30,14 @@ TEST_SET_SIZE_LIST = [TEST_SET_SIZE] * TEST_NUM_SETS
 class SetGeneratorTest(parameterized.TestCase):
 
   @parameterized.parameters(
-      (set_generator.IndependentSetGenerator, {}),
+      (set_generator.IndependentSetGenerator,
+       {'universe_size': TEST_UNIVERSE_SIZE}),
       (set_generator.ExponentialBowSetGenerator,
-       {'user_activity_association': 'independent'}),
+       {'universe_size': TEST_UNIVERSE_SIZE,
+        'user_activity_association': 'independent'}),
       (set_generator.ExponentialBowSetGenerator,
-       {'user_activity_association': 'identical'}),
+       {'universe_size': TEST_UNIVERSE_SIZE,
+        'user_activity_association': 'identical'}),
       (set_generator.SequentiallyCorrelatedSetGenerator,
        {'order': 'original', 'correlated_sets': 'all', 'shared_prop': 0.2}),
       (set_generator.SequentiallyCorrelatedSetGenerator,
@@ -63,11 +66,11 @@ class SetGeneratorTest(parameterized.TestCase):
         given by the global variables TEST_UNIVERSE_SIZE and TEST_SET_SIZE_LIST.
     """
     factory = set_generator_class.get_generator_factory_with_num_and_size(
-        universe_size=TEST_UNIVERSE_SIZE, num_sets=TEST_NUM_SETS,
+        num_sets=TEST_NUM_SETS,
         set_size=TEST_SET_SIZE, **kwargs)
     gen_from_factory = factory(np.random.RandomState(1))
     gen_from_class = set_generator_class(
-        universe_size=TEST_UNIVERSE_SIZE, set_sizes=TEST_SET_SIZE_LIST,
+        set_sizes=TEST_SET_SIZE_LIST,
         **kwargs, random_state=np.random.RandomState(1))
     set_list_gen_from_factory = []
     for ids in gen_from_factory:
@@ -119,11 +122,14 @@ class SetGeneratorTest(parameterized.TestCase):
     self.assertSameElements(set_list_gen_from_factory, set_list_gen_from_class)
 
   @parameterized.parameters(
-      (set_generator.IndependentSetGenerator, {}),
+      (set_generator.IndependentSetGenerator,
+       {'universe_size': TEST_UNIVERSE_SIZE}),
       (set_generator.ExponentialBowSetGenerator,
-       {'user_activity_association': 'independent'}),
+       {'universe_size': TEST_UNIVERSE_SIZE,
+        'user_activity_association': 'independent'}),
       (set_generator.ExponentialBowSetGenerator,
-       {'user_activity_association': 'identical'}),
+       {'universe_size': TEST_UNIVERSE_SIZE,
+        'user_activity_association': 'identical'}),
       (set_generator.SequentiallyCorrelatedSetGenerator,
        {'order': 'original', 'correlated_sets': 'all', 'shared_prop': 0.2}),
       (set_generator.SequentiallyCorrelatedSetGenerator,
@@ -132,11 +138,10 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_set_generator_factory_with_set_size_list(self, set_generator_class,
                                                     kwargs):
     factory = set_generator_class.get_generator_factory_with_set_size_list(
-        universe_size=TEST_UNIVERSE_SIZE, set_size_list=TEST_SET_SIZE_LIST,
-        **kwargs)
+        set_size_list=TEST_SET_SIZE_LIST, **kwargs)
     gen_from_factory = factory(np.random.RandomState(1))
     gen_from_class = set_generator_class(
-        universe_size=TEST_UNIVERSE_SIZE, set_sizes=TEST_SET_SIZE_LIST,
+        set_sizes=TEST_SET_SIZE_LIST,
         **kwargs, random_state=np.random.RandomState(1))
     set_list_gen_from_factory = []
     for ids in gen_from_factory:
@@ -341,7 +346,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_sequentially_correlated_all_previous_generator_original(self):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order='original', correlated_sets='all', universe_size=30,
+        order='original', correlated_sets='all',
         shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
@@ -353,7 +358,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_sequentially_correlated_all_previous_generator_different_sizes(self):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order='original', correlated_sets='all', universe_size=100,
+        order='original', correlated_sets='all',
         shared_prop=0.2, set_sizes=[10, 15, 20, 20], random_state=rs)
     expected_overlap_size = iter([2, 3, 4])
     set_ids_list = [set_ids for set_ids in sc_gen]
@@ -366,7 +371,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_sequentially_correlated_all_previous_generator_reversed(self):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order='reversed', correlated_sets='all', universe_size=30,
+        order='reversed', correlated_sets='all',
         shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen][::-1]
     previous_set_ids = set(set_ids_list[0])
@@ -378,7 +383,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_sequentially_correlated_one_previous_generator_original(self):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order='original', correlated_sets='one', universe_size=30,
+        order='original', correlated_sets='one',
         shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen]
     previous_set_ids = set(set_ids_list[0])
@@ -392,7 +397,7 @@ class SetGeneratorTest(parameterized.TestCase):
   def test_sequentially_correlated_one_previous_generator_reversed(self):
     rs = np.random.RandomState(1)
     sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
-        order='reversed', correlated_sets='one', universe_size=30,
+        order='reversed', correlated_sets='one',
         shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     set_ids_list = [set_ids for set_ids in sc_gen][::-1]
     previous_set_ids = set(set_ids_list[0])
@@ -407,12 +412,29 @@ class SetGeneratorTest(parameterized.TestCase):
     rs = np.random.RandomState(1)
     with self.assertRaises(ValueError):
       _ = set_generator.SequentiallyCorrelatedSetGenerator(
-          order='not_implemented', correlated_sets='all', universe_size=30,
+          order='not_implemented', correlated_sets='all',
           shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
     with self.assertRaises(ValueError):
       _ = set_generator.SequentiallyCorrelatedSetGenerator(
-          order='random', correlated_sets='not_implemented', universe_size=30,
+          order='random', correlated_sets='not_implemented',
           shared_prop=0.2, set_sizes=[10] * 3, random_state=rs)
+
+  @parameterized.parameters(
+      (set_generator.CORRELATED_SETS_ALL,),
+      (set_generator.CORRELATED_SETS_ONE,))
+  def test_sequentially_correlated_generator_overlap_size_larger_than_set_size(
+      self, correlation_type):
+    sc_gen = set_generator.SequentiallyCorrelatedSetGenerator(
+        order=set_generator.ORDER_ORIGINAL, correlated_sets=correlation_type,
+        shared_prop=0.5, set_sizes=[10, 1],
+        random_state=np.random.RandomState())
+    set_ids_list = [set_ids for set_ids in sc_gen]
+    self.assertLen(set_ids_list[0], 10,
+                   f'{correlation_type}: First set size not correct.')
+    self.assertLen(set_ids_list[1], 1,
+                   f'{correlation_type}: Second set size not correct.')
+    self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]), 1,
+                   f'{correlation_type}: Overlap set size not correct.')
 
 
 if __name__ == '__main__':

--- a/tests/interoperability_test.py
+++ b/tests/interoperability_test.py
@@ -371,7 +371,6 @@ class InteroperabilityTest(absltest.TestCase):
             order=self.order,
             correlated_sets=set_generator.CORRELATED_SETS_ALL,
             shared_prop=self.shared_prop,
-            universe_size=self.universe_size,
             num_sets=self.number_of_sets,
             set_size=self.set_size))
     self.simulate_with_set_generator(set_generator_factory,
@@ -385,7 +384,6 @@ class InteroperabilityTest(absltest.TestCase):
             order=self.order,
             correlated_sets=set_generator.CORRELATED_SETS_ALL,
             shared_prop=self.shared_prop,
-            universe_size=self.universe_size,
             set_size_list=self.set_size_list))
     self.simulate_with_set_generator(set_generator_factory,
                                      self.name_to_non_noised_estimator_config)
@@ -397,7 +395,6 @@ class InteroperabilityTest(absltest.TestCase):
             order=self.order,
             correlated_sets=set_generator.CORRELATED_SETS_ONE,
             shared_prop=self.shared_prop,
-            universe_size=self.universe_size,
             num_sets=self.number_of_sets,
             set_size=self.set_size))
     self.simulate_with_set_generator(set_generator_factory,
@@ -410,7 +407,6 @@ class InteroperabilityTest(absltest.TestCase):
             order=self.order,
             correlated_sets=set_generator.CORRELATED_SETS_ONE,
             shared_prop=self.shared_prop,
-            universe_size=self.universe_size,
             set_size_list=self.set_size_list))
     self.simulate_with_set_generator(set_generator_factory,
                                      self.name_to_noised_estimator_config)


### PR DESCRIPTION
1. Sequentially correlated set generator will run into error if the new set is smaller than the overlap set size. This PR fix this bug by capping the size of the overlap set if it is larger than the new set. Also add a unit test for this feature.
2. The sequentially correlated set generator does not need the universe size. Remove this argument in order to reduce potential bug when creating the evaluation configuration. Also modified the interoperability test and the evaluation configs and its tests.