### PR TITLE
Add epsilon arg to the surreal denoiser.

### DIFF
--- a/src/estimators/bloom_filters.py
+++ b/src/estimators/bloom_filters.py
@@ -501,30 +501,15 @@ class DenoiserBase(object):
 class SurrealDenoiser(DenoiserBase):
   """A closed form denoiser for a list of Any Distribution Bloom Filter."""
 
-  def __init__(self, epsilon=None, flip_one_probability=None,
-               flip_zero_probability=None):
+  def __init__(self, epsilon):
     """Construct a denoiser.
 
     Args:
       epsilon: a non-negative differential privacy parameter.
-      flip_one_probability: the bit flipping probability of 1 bits. It will be
-        ignored if either espilon or probability is given.
-      flip_zero_probability: the bit flipping probability of 0 bits. It will be
-        ignored if either espilon or probability is given.
-
-    Raises:
-      ValueError: if none of epsilon, probability, or flip_one_probability and
-        flip_zero_probability is given.
     """
     if epsilon is not None:
       # Currently only support one hash function.
-      probability = get_probability_of_flip(epsilon, 1)
-      self._probability = (probability, probability)
-    elif flip_one_probability is not None and flip_zero_probability is not None:
-      self._probability = (flip_zero_probability, flip_one_probability)
-    else:
-      raise ValueError("Should provide epsilon, or both "
-                       "flip_one_probability and flip_zero_probability.")
+      self._probability = get_probability_of_flip(epsilon, 1)
 
   def  __call__(self, sketch_list):
     return self._denoise(sketch_list)
@@ -549,8 +534,8 @@ class SurrealDenoiser(DenoiserBase):
         "Will extend to multiple hash functions later.")
     denoised_sketch = copy.deepcopy(sketch)
     expected_zeros = (
-        - denoised_sketch.sketch * self._probability[1]
-        + (1 - denoised_sketch.sketch) * (1 - self._probability[1]))
+        - denoised_sketch.sketch * self._probability
+        + (1 - denoised_sketch.sketch) * (1 - self._probability))
     denoised_sketch.sketch = 1 - expected_zeros / (
-        1 - self._probability[1] - self._probability[0])
+        1 - self._probability - self._probability)
     return denoised_sketch

--- a/src/estimators/bloom_filters.py
+++ b/src/estimators/bloom_filters.py
@@ -501,14 +501,12 @@ class DenoiserBase(object):
 class SurrealDenoiser(DenoiserBase):
   """A closed form denoiser for a list of Any Distribution Bloom Filter."""
 
-  def __init__(self, epsilon=None, probability=None, flip_one_probability=None,
+  def __init__(self, epsilon=None, flip_one_probability=None,
                flip_zero_probability=None):
     """Construct a denoiser.
 
     Args:
       epsilon: a non-negative differential privacy parameter.
-      probability: the bit flipping probability. It will be ignored if epsilon
-        is given.
       flip_one_probability: the bit flipping probability of 1 bits. It will be
         ignored if either espilon or probability is given.
       flip_zero_probability: the bit flipping probability of 0 bits. It will be
@@ -522,12 +520,10 @@ class SurrealDenoiser(DenoiserBase):
       # Currently only support one hash function.
       probability = get_probability_of_flip(epsilon, 1)
       self._probability = (probability, probability)
-    elif probability is not None:
-      self._probability = (probability, probability)
     elif flip_one_probability is not None and flip_zero_probability is not None:
       self._probability = (flip_zero_probability, flip_one_probability)
     else:
-      raise ValueError("Should provide epsilon, or probability, or both "
+      raise ValueError("Should provide epsilon, or both "
                        "flip_one_probability and flip_zero_probability.")
 
   def  __call__(self, sketch_list):

--- a/src/estimators/tests/bloom_filters_test.py
+++ b/src/estimators/tests/bloom_filters_test.py
@@ -322,22 +322,16 @@ class BlipNoiserTest(absltest.TestCase):
     self.assertAlmostEqual(average_bits, 0.75, delta=0.01)
 
 
-class SurrealDenoiserTest(parameterized.TestCase):
+class SurrealDenoiserTest(absltest.TestCase):
 
-  @parameterized.parameters(
-      ({'epsilon': math.log(3)},),
-      ({'flip_one_probability': 0.25, 'flip_zero_probability': 0.25},),
-  )
-  def test_denoiser_estimation_correct(self, kwargs):
+  def test_denoiser_estimation_correct(self):
     noised_adbf = UniformBloomFilter(4, random_seed=1)
     noised_adbf.sketch[0] = 1
-    denoiser = SurrealDenoiser(**kwargs)
+    denoiser = SurrealDenoiser(epsilon=math.log(3))
     denoised_adbf = denoiser([noised_adbf])[0]
     expected = np.array([1.5, -0.5, -0.5, -0.5])
-    kwarg_names = ', '.join(kwargs.keys())
     np.testing.assert_allclose(
-        denoised_adbf.sketch, expected, atol=0.01,
-        err_msg=f'Denoiser does not work with: {kwarg_names}.')
+        denoised_adbf.sketch, expected, atol=0.01)
 
 
 if __name__ == '__main__':

--- a/src/estimators/tests/bloom_filters_test.py
+++ b/src/estimators/tests/bloom_filters_test.py
@@ -241,11 +241,11 @@ class FirstMomentEstimatorTest(parameterized.TestCase):
     self.assertAlmostEqual(estimate, truth, 3, msg=method)
 
   def test_denoise_and_union(self):
-    noiser = FixedProbabilityBitFlipNoiser(
-        probability=0.25, random_state=np.random.RandomState(5))
+    noiser = BlipNoiser(
+        epsilon=math.log(3), random_state=np.random.RandomState(5))
     estimator = FirstMomentEstimator(
         method='log',
-        denoiser=SurrealDenoiser(probability=0.25))
+        denoiser=SurrealDenoiser(epsilon=math.log(3)))
     results = []
     truth = 1000
     for i in range(100):
@@ -326,7 +326,6 @@ class SurrealDenoiserTest(parameterized.TestCase):
 
   @parameterized.parameters(
       ({'epsilon': math.log(3)},),
-      ({'probability': 0.25},),
       ({'flip_one_probability': 0.25, 'flip_zero_probability': 0.25},),
   )
   def test_denoiser_estimation_correct(self, kwargs):

--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Evaluation configurations."""
+import math
 import numpy as np
 
 from wfa_cardinality_estimation_evaluation_framework.estimators import bloom_filters
@@ -397,7 +398,7 @@ LOG_BLOOM_FILTER_1E5_LN3_FIRST_MOMENT_LOG = SketchEstimatorConfig(
         length=10**5),
     estimator=bloom_filters.FirstMomentEstimator(
         method=bloom_filters.FirstMomentEstimator.METHOD_LOG,
-        denoiser=bloom_filters.SurrealDenoiser(probability=0.25)),
+        denoiser=bloom_filters.SurrealDenoiser(epsilon=math.log(3))),
     sketch_noiser=bloom_filters.BlipNoiser(epsilon=np.log(3)))
 
 LOG_BLOOM_FILTER_1E5_INFTY_FIRST_MOMENT_LOG = SketchEstimatorConfig(
@@ -413,7 +414,7 @@ EXP_BLOOM_FILTER_1E5_10_LN3_FIRST_MOMENT_LOG = SketchEstimatorConfig(
         length=10**5, decay_rate=10),
     estimator=bloom_filters.FirstMomentEstimator(
         method=bloom_filters.FirstMomentEstimator.METHOD_EXP,
-        denoiser=bloom_filters.SurrealDenoiser(probability=0.25)),
+        denoiser=bloom_filters.SurrealDenoiser(epsilon=math.log(3))),
     sketch_noiser=bloom_filters.BlipNoiser(epsilon=np.log(3)))
 
 EXP_BLOOM_FILTER_1E5_10_INFTY_FIRST_MOMENT_LOG = SketchEstimatorConfig(

--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -399,7 +399,7 @@ LOG_BLOOM_FILTER_1E5_LN3_FIRST_MOMENT_LOG = SketchEstimatorConfig(
     estimator=bloom_filters.FirstMomentEstimator(
         method=bloom_filters.FirstMomentEstimator.METHOD_LOG,
         denoiser=bloom_filters.SurrealDenoiser(epsilon=math.log(3))),
-    sketch_noiser=bloom_filters.BlipNoiser(epsilon=np.log(3)))
+    sketch_noiser=bloom_filters.BlipNoiser(epsilon=math.log(3)))
 
 LOG_BLOOM_FILTER_1E5_INFTY_FIRST_MOMENT_LOG = SketchEstimatorConfig(
     name='log_bloom_filter-1e5-infty-first_moment_log',
@@ -415,7 +415,7 @@ EXP_BLOOM_FILTER_1E5_10_LN3_FIRST_MOMENT_LOG = SketchEstimatorConfig(
     estimator=bloom_filters.FirstMomentEstimator(
         method=bloom_filters.FirstMomentEstimator.METHOD_EXP,
         denoiser=bloom_filters.SurrealDenoiser(epsilon=math.log(3))),
-    sketch_noiser=bloom_filters.BlipNoiser(epsilon=np.log(3)))
+    sketch_noiser=bloom_filters.BlipNoiser(epsilon=math.log(3)))
 
 EXP_BLOOM_FILTER_1E5_10_INFTY_FIRST_MOMENT_LOG = SketchEstimatorConfig(
     name='exp_bloom_filter-1e5_10-infty-first_moment_exp',
@@ -442,7 +442,7 @@ VECTOR_OF_COUNTS_4096_LN3_SEQUENTIAL = SketchEstimatorConfig(
     sketch_factory=vector_of_counts.VectorOfCounts.get_sketch_factory(
         num_buckets=4096),
     estimator=vector_of_counts.SequentialEstimator(),
-    sketch_noiser=vector_of_counts.LaplaceNoiser(epsilon=np.log(3)))
+    sketch_noiser=vector_of_counts.LaplaceNoiser(epsilon=math.log(3)))
 
 VECTOR_OF_COUNTS_4096_INFTY_SEQUENTIAL = SketchEstimatorConfig(
     name='vector_of_counts-4096-infty-sequential',

--- a/tests/interoperability_test.py
+++ b/tests/interoperability_test.py
@@ -18,7 +18,7 @@ work with the simulation and set generation code in simulations/, and (2) the
 estimator, set generator and simulator works with the evaluator, analyzer and
 report generator.
 """
-
+import math
 from absl.testing import absltest
 import numpy as np
 from wfa_cardinality_estimation_evaluation_framework.estimators.bloom_filters import BlipNoiser
@@ -159,8 +159,7 @@ class InteroperabilityTest(absltest.TestCase):
             self.sketch_size, self.geometic_bloom_filter_probability),
         estimator=FirstMomentEstimator(
             method='geo',
-            denoiser=SurrealDenoiser(
-                probability=self.noiser_flip_probability)),
+            denoiser=SurrealDenoiser(epsilon=math.log(3))),
         sketch_noiser=BlipNoiser(self.noiser_epsilon, self.noise_random_state))
 
     noised_estimator_config_logarithmic_bloom_filter = SketchEstimatorConfig(
@@ -169,8 +168,7 @@ class InteroperabilityTest(absltest.TestCase):
             self.sketch_size),
         estimator=FirstMomentEstimator(
             method='log',
-            denoiser=SurrealDenoiser(
-                probability=self.noiser_flip_probability)),
+            denoiser=SurrealDenoiser(epsilon=math.log(3))),
         sketch_noiser=BlipNoiser(self.noiser_epsilon, self.noise_random_state))
 
     noised_estimator_config_exponential_bloom_filter = SketchEstimatorConfig(
@@ -179,8 +177,7 @@ class InteroperabilityTest(absltest.TestCase):
             self.sketch_size, self.exponential_bloom_filter_decay_rate),
         estimator=FirstMomentEstimator(
             method='exp',
-            denoiser=SurrealDenoiser(
-                probability=self.noiser_flip_probability)),
+            denoiser=SurrealDenoiser(epsilon=math.log(3))),
         sketch_noiser=BlipNoiser(self.noiser_epsilon, self.noise_random_state))
 
     noised_estimator_config_voc = SketchEstimatorConfig(


### PR DESCRIPTION
Add epsilon argument to the surreal denoiser and related unit tests, in order to support more comprehensive evaluations of ADBF under different epsilons.