### PR TITLE
Modify the modules in the evaluations folder to support more simulation parameters.

### DIFF
--- a/examples/basic_comparison.py
+++ b/examples/basic_comparison.py
@@ -30,9 +30,9 @@ from wfa_cardinality_estimation_evaluation_framework.estimators.hyper_log_log im
 from wfa_cardinality_estimation_evaluation_framework.estimators.hyper_log_log import HyperLogLogPlusPlus
 from wfa_cardinality_estimation_evaluation_framework.estimators.vector_of_counts import SequentialEstimator
 from wfa_cardinality_estimation_evaluation_framework.estimators.vector_of_counts import VectorOfCounts
+from wfa_cardinality_estimation_evaluation_framework.evaluations.configs import SketchEstimatorConfig
 from wfa_cardinality_estimation_evaluation_framework.simulations import set_generator
 from wfa_cardinality_estimation_evaluation_framework.simulations.simulator import Simulator
-from wfa_cardinality_estimation_evaluation_framework.simulations.simulator import SketchEstimatorConfig
 
 FLAGS = flags.FLAGS
 
@@ -50,7 +50,8 @@ flags.DEFINE_integer('exponential_bloom_filter_decay_rate', 10,
 flags.DEFINE_integer('num_bloom_filter_hashes', 3,
                      'The number of hashes for the bloom filter to use')
 flags.DEFINE_float('geometric_bloom_filter_probability', 0.0015,
-                     'probability of geometric distribution')
+                   'probability of geometric distribution')
+
 
 def main(argv):
   if len(argv) > 1:

--- a/src/evaluations/configs.py
+++ b/src/evaluations/configs.py
@@ -15,8 +15,8 @@
 import collections
 
 _SketchEstimatorConfig = collections.namedtuple(
-    'SketchEstimatorConfig',
-    ['name', 'sketch_factory', 'estimator', 'noiser'])
+    'EstimatorConfig', ['name', 'sketch_factory', 'estimator', 'sketch_noiser',
+                        'estimate_noiser', 'max_frequency'])
 
 
 # This class exists as a placeholder for a docstring.
@@ -24,14 +24,23 @@ class SketchEstimatorConfig(_SketchEstimatorConfig):
   """A subclass of namedtuple for providing a estimator config to the simulator.
 
   The arguments to the named tuple are as follows:
-    name: A string representing the name of the estimator.
+    name: A string that represents the name of the sketch and estimator.
     sketch_factory: A callable that takes as a single argument a
       numpy.random.RandomState and returns a class that conforms to
       cardinality_estimator_base.Sketch.
     estimator: A class that conforms to cardinality_estimator_base.Estimator.
-    noiser: A class that conforms to cardinality_estimator_base.Noiser.
+    sketch_noiser: A class that conforms to
+      cardinality_estimator_base.SketchNoiser.
+    estimate_noiser: A class that conforms to
+      cardinality_estimator_base.EstimateNoiser.
+    max_frequency: The maximum frequency for which estimates should be produced.
   """
-  pass
+
+  def __new__(cls, name, sketch_factory, estimator, sketch_noiser=None,
+              estimate_noiser=None, max_frequency=1):
+    return super(cls, SketchEstimatorConfig).__new__(
+        cls, name, sketch_factory, estimator, sketch_noiser, estimate_noiser,
+        max_frequency)
 
 
 _ScenarioConfig = collections.namedtuple(

--- a/src/evaluations/report_generator.py
+++ b/src/evaluations/report_generator.py
@@ -24,6 +24,8 @@ from wfa_cardinality_estimation_evaluation_framework.evaluations.analyzer import
 from wfa_cardinality_estimation_evaluation_framework.evaluations.analyzer import KEY_NUM_ESTIMABLE_SETS_STATS_DF
 from wfa_cardinality_estimation_evaluation_framework.evaluations.analyzer import KEY_RUNNING_TIME_DF
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data import evaluation_configs
+from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import ESTIMATE_EPSILON
+from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import SKETCH_EPSILON
 from wfa_cardinality_estimation_evaluation_framework.simulations import simulator
 
 pd.set_option('display.max_colwidth', None)
@@ -161,10 +163,10 @@ class ReportGenerator:
           df[analyzer.NUM_ESTIMABLE_SETS].astype('str')
           + '<br>relative_error: mean='
           + df[error_metric_column + '_mean'].round(
-            RELATIVE_ERROR_FORMAT_ACCURACY).astype('str')
+              RELATIVE_ERROR_FORMAT_ACCURACY).astype('str')
           + ', std='
           + df[error_metric_column + '_std'].round(
-            RELATIVE_ERROR_FORMAT_ACCURACY).astype('str')
+              RELATIVE_ERROR_FORMAT_ACCURACY).astype('str')
       )
       df[ESTIMABLE_CRITERIA_COLNAME] = (
           df[analyzer.PROPORTION_OF_RUNS_NAME].apply('{0:.0%}'.format)
@@ -225,7 +227,8 @@ class ReportGenerator:
           row[evaluation_configs.SKETCH] + ', '
           + row[evaluation_configs.ESTIMATOR]  + '<br>'
           + 'sketch_config: ' + row[evaluation_configs.SKETCH_CONFIG] + '<br>'
-          + 'epsilon: ' + row[evaluation_configs.EPSILON])
+          + 'sketch_epsilon: ' + row[SKETCH_EPSILON]
+          + 'estimate_epsilon: ' + row[ESTIMATE_EPSILON])
 
       return (
           '<figure>'
@@ -242,7 +245,7 @@ class ReportGenerator:
       plot_df['link'] = plot_df.apply(_get_boxplot_html, axis=1)
       plot_df = plot_df.pivot_table(
           values='link',
-          index=evaluation_configs.EPSILON,
+          index=SKETCH_EPSILON,
           columns=evaluation_configs.SKETCH,
           aggfunc=''.join)
       plot_df_html_list.append(
@@ -252,18 +255,29 @@ class ReportGenerator:
 
   def generate_html_report(self):
     """Generate HTML report."""
-    # Generate the number of estimable sets html tables by epsilon.
-    epsilon_list = (
+    # Generate the number of estimable sets html tables by sketch epsilon
+    # and estimate epsilon pairs.
+    unique_epsilons = (
         self.analysis_results[KEY_NUM_ESTIMABLE_SETS_STATS_DF][
-            evaluation_configs.EPSILON].unique())
+            [SKETCH_EPSILON, ESTIMATE_EPSILON]].drop_duplicates())
     num_estimable_sets_stats_df_html_list = []
     df = self.analysis_results[KEY_NUM_ESTIMABLE_SETS_STATS_DF]
-    for epsilon in epsilon_list:
-      one_html = ReportGenerator.widen_num_estimable_sets_df(
-          df.loc[df['epsilon'] == epsilon], self.error_metric_column
+
+    def _generate_html_for_one_epsilon(row):
+      table_html = ReportGenerator.widen_num_estimable_sets_df(
+          df.loc[
+              (df[SKETCH_EPSILON] == row[SKETCH_EPSILON])
+              & (df[ESTIMATE_EPSILON] == row[ESTIMATE_EPSILON])],
+          self.error_metric_column
       ).to_html(escape=False)
-      one_html = f'<h4>epsilon={epsilon}</h4><p>' + one_html + '</p>'
-      num_estimable_sets_stats_df_html_list.append(one_html)
+      return (
+          f'<h4>sketch_epsilon={row[SKETCH_EPSILON]}, '
+          + f'estimate_epsilon={row[ESTIMATE_EPSILON]}</h4><p>'
+          + table_html + '</p>')
+
+    num_estimable_sets_stats_df_html_list = (
+        unique_epsilons.apply(_generate_html_for_one_epsilon, axis=1)
+        .tolist())
     num_estimable_sets_stats_df_html = '\n'.join(
         num_estimable_sets_stats_df_html_list)
 
@@ -292,7 +306,7 @@ class ReportGenerator:
 
     return report_html
 
-  
+
 class CardinalityReportGenerator(ReportGenerator):
   """Generate HTML report for the cardinality estimator evaluation."""
 

--- a/src/evaluations/tests/analyzer_test.py
+++ b/src/evaluations/tests/analyzer_test.py
@@ -33,11 +33,11 @@ class AnalyzerTest(absltest.TestCase):
 
   def setUp(self):
     super(AnalyzerTest, self).setUp()
-    exact_set_lossless = simulator.SketchEstimatorConfig(
+    exact_set_lossless = configs.SketchEstimatorConfig(
         name='exact_set-infty-infty-lossless',
         sketch_factory=exact_set.ExactMultiSet.get_sketch_factory(),
         estimator=exact_set.LosslessEstimator())
-    exact_set_less_one = simulator.SketchEstimatorConfig(
+    exact_set_less_one = configs.SketchEstimatorConfig(
         name='exact_set-infty-infty-less_one',
         sketch_factory=exact_set.ExactMultiSet.get_sketch_factory(),
         estimator=exact_set.LessOneEstimator(),

--- a/src/evaluations/tests/evaluator_test.py
+++ b/src/evaluations/tests/evaluator_test.py
@@ -31,11 +31,11 @@ class EvaluatorTest(absltest.TestCase):
   def setUp(self):
     super(EvaluatorTest, self).setUp()
 
-    exact_set_lossless = simulator.SketchEstimatorConfig(
+    exact_set_lossless = configs.SketchEstimatorConfig(
         name='exact_set_lossless',
         sketch_factory=exact_set.ExactMultiSet.get_sketch_factory(),
         estimator=exact_set.LosslessEstimator())
-    exact_set_less_one = simulator.SketchEstimatorConfig(
+    exact_set_less_one = configs.SketchEstimatorConfig(
         name='exact_set_less_one',
         sketch_factory=exact_set.ExactMultiSet.get_sketch_factory(),
         estimator=exact_set.LessOneEstimator(),

--- a/tests/interoperability_test.py
+++ b/tests/interoperability_test.py
@@ -40,13 +40,10 @@ from wfa_cardinality_estimation_evaluation_framework.estimators.hyper_log_log im
 from wfa_cardinality_estimation_evaluation_framework.estimators.vector_of_counts import LaplaceNoiser
 from wfa_cardinality_estimation_evaluation_framework.estimators.vector_of_counts import SequentialEstimator
 from wfa_cardinality_estimation_evaluation_framework.estimators.vector_of_counts import VectorOfCounts
-from wfa_cardinality_estimation_evaluation_framework.evaluations import analyzer
-from wfa_cardinality_estimation_evaluation_framework.evaluations import configs
-from wfa_cardinality_estimation_evaluation_framework.evaluations import evaluator
-from wfa_cardinality_estimation_evaluation_framework.evaluations import report_generator
+from wfa_cardinality_estimation_evaluation_framework.evaluations.configs import SketchEstimatorConfig
+from wfa_cardinality_estimation_evaluation_framework.evaluations import run_evaluation
 from wfa_cardinality_estimation_evaluation_framework.simulations import set_generator
 from wfa_cardinality_estimation_evaluation_framework.simulations.simulator import Simulator
-from wfa_cardinality_estimation_evaluation_framework.simulations.simulator import SketchEstimatorConfig
 
 
 class InteroperabilityTest(absltest.TestCase):
@@ -205,27 +202,6 @@ class InteroperabilityTest(absltest.TestCase):
     self.name_to_noised_estimator_config = {
         config.name: config for config in noised_config_list
     }
-
-    # For testing the compatibility of evaluator, analyzer and report_generator
-    # with the estimators, set generators and simulator.
-    self.evaluation_config = configs.EvaluationConfig(
-        name='evaluation_config',
-        num_runs=1,
-        scenario_config_list=[
-            configs.ScenarioConfig(
-                name='independent',
-                set_generator_factory=(
-                    set_generator.IndependentSetGenerator
-                    .get_generator_factory_with_num_and_size(
-                        universe_size=2, num_sets=1, set_size=1)))
-        ])
-
-    self.sketch_estimator_config_list = [
-        SketchEstimatorConfig(
-            name='exact_set-0-infty-lossless',
-            sketch_factory=ExactMultiSet.get_sketch_factory(),
-            estimator=LosslessEstimator())
-    ]
 
   def simulate_with_set_generator(self, set_generator_factory, config_dict):
     for _, estimator_method_config in config_dict.items():
@@ -417,35 +393,29 @@ class InteroperabilityTest(absltest.TestCase):
     the evaluation, analyzes results, and generates a report, which should not
     run into any error.
     """
-    # Run evaluation.
-    evaluator_out_dir = self.create_tempdir('evaluator').full_path
-    evaluation_run_name = 'interoperability_test_for_evaluator'
-    generate_results = evaluator.Evaluator(
-        evaluation_config=self.evaluation_config,
-        sketch_estimator_config_list=self.sketch_estimator_config_list,
-        run_name=evaluation_run_name,
-        out_dir=evaluator_out_dir,
-        workers=0)
-    generate_results()
-
-    # Run analysis.
-    analysis_out_dir = self.create_tempdir('analyzer').full_path
-    generate_summary = analyzer.CardinalityEstimatorEvaluationAnalyzer(
-        out_dir=analysis_out_dir,
-        evaluation_directory=evaluator_out_dir,
-        evaluation_run_name=evaluation_run_name,
-        evaluation_name=self.evaluation_config.name,
-        estimable_criteria_list=[(0.1, 0.9)])
-    generate_summary()
-
-    # Generator report.
-    report_out_dir = self.create_tempdir('report').full_path
-    generate_report = report_generator.CardinalityReportGenerator(
-        out_dir=report_out_dir,
-        analysis_out_dir=analysis_out_dir,
-        evaluation_run_name=evaluation_run_name,
-        evaluation_name=self.evaluation_config.name)
-    generate_report()
+    run_evaluation._run(
+        run_evaluation=True,
+        run_analysis=True,
+        generate_html_report=True,
+        evaluation_out_dir=self.create_tempdir('evaluator').full_path,
+        analysis_out_dir=self.create_tempdir('analyzer').full_path,
+        report_out_dir=self.create_tempdir('report').full_path,
+        evaluation_config='smoke_test',
+        sketch_estimator_configs=[
+            'log_bloom_filter-1e5-first_moment_log-1.0986-infty',
+            'vector_of_counts-4096-sequential-infty-1.0986',
+        ],
+        evaluation_run_name='interoperability_test_for_evaluator',
+        num_runs=1,
+        num_workers=0,
+        error_margin=[0.05],
+        proportion_of_runs=[0.95],
+        boxplot_xlabel_rotate=90,
+        boxplot_size_width_inch=6,
+        boxplot_size_height_inch=4,
+        analysis_type='cardinality',
+        max_frequency=10
+    )
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
1. Modify the sketch estimator config so that it can support both sketch epsilon and estimate epsilon.
2. Move the SketchEstimatorConfig from simulator to configs.
3. Modify the interoperability test to make sure all run_evaluation.py is well tested.