### PR TITLE
Uakyol/stratified sketch noise

### DIFF
--- a/src/estimators/stratified_sketch.py
+++ b/src/estimators/stratified_sketch.py
@@ -63,6 +63,7 @@ class ExactSetOperator(object):
     result._ids = {x: 1 for x in result_key_set.difference(that_key_set)}
     return result
 
+
 class StratifiedSketch(SketchBase):
   """A frequency sketch that contains cardinality sketches per frequency bucket."""
 
@@ -78,14 +79,14 @@ class StratifiedSketch(SketchBase):
 
     def f(random_seed):
       return cls(
-          random_seed=random_seed,
           max_freq=max_freq,
+          cardinality_sketch_factory=cardinality_sketch_factory,
+          random_seed=random_seed,
           underlying_set=underlying_set,
           noiser_class=noiser_class,
           epsilon=epsilon,
           epsilon_split=epsilon_split,
-          union=union,
-          cardinality_sketch_factory=cardinality_sketch_factory)
+          union=union)
 
     return f
 
@@ -104,12 +105,14 @@ class StratifiedSketch(SketchBase):
       max_freq: the maximum targeting frequency level. For example, if it is set
         to 3, then the sketches will include frequency=1, 2, 3+ (frequency >=
         3).
+      cardinality_sketch_factory: A cardinality sketch factory.
       random_seed: This arg exists in order to conform to
         simulator.EstimatorConfig.sketch_factory.
-      cardinality_sketch_factory: A cardinality sketch factory.
-      noiser : A noiser instance of base.EstimateNoiserBase.
+      noiser : A noiser class that is a subclass of base.EstimateNoiserBase.
       epsilon : Total privacy budget to spend for noising this sketch.
       epsilon_split : Ratio of privacy budget to spend to noise 1+ sketch.
+      underlying_set : ExactMultiSet object that holds the frequency for each
+        item for this Stratified Sketch.
       union : Function to be used to calculate the 1+ sketch as the union of the
         others.
     """
@@ -519,4 +522,5 @@ class SequentialEstimator(EstimatorBase):
     return self.pairwise_estimator.estimate_cardinality(merged)
 
   def merge(self, sketches_list):
-    return functools.reduce(self.pairwise_estimator.merge_sketches, sketches_list)
+    return functools.reduce(self.pairwise_estimator.merge_sketches,
+                            sketches_list)

--- a/src/estimators/stratified_sketch.py
+++ b/src/estimators/stratified_sketch.py
@@ -514,7 +514,7 @@ class SequentialEstimator(EstimatorBase):
 
   def __call__(self, sketches_list):
     for i, sketch in enumerate(sketches_list):
-      sketches_list[i] = self.pairwise_estimator.denoise_sketch(sketch)
+      sketches_list[i] = self.pairwise_estimator.prepare_sketch(sketch)
     merged = self.merge(sketches_list)
     return self.pairwise_estimator.estimate_cardinality(merged)
 

--- a/src/estimators/stratified_sketch.py
+++ b/src/estimators/stratified_sketch.py
@@ -24,7 +24,11 @@ ONE_PLUS = '1+'
 
 
 class ExactSetOperator(object):
-  """Set operations for ExactSet."""
+  """Set operations for ExactSet.
+
+  The methods below all accept an ExactMultiSet object and returning an
+  ExactMultiSet object.
+  """
 
   @classmethod
   def union(cls, this, that):
@@ -134,12 +138,14 @@ class StratifiedSketch(SketchBase):
     self.union = union
     self.one_plus_noiser = None
     self.rest_noiser = None
+
     if noiser_class is not None:
-      self.rest_noiser = noiser_class(epsilon=epsilon * (1 - epsilon_split))
-      if epsilon_split == 0:
-        self.one_plus_noiser = noiser_class(epsilon=epsilon)
-      else:
+      if epsilon_split != 0:
         self.one_plus_noiser = noiser_class(epsilon=epsilon * epsilon_split)
+        self.rest_noiser = noiser_class(epsilon=epsilon * (1 - epsilon_split))
+      else:
+        self.one_plus_noiser = noiser_class(epsilon=epsilon)
+        self.rest_noiser = noiser_class(epsilon=epsilon)
 
   def create_frequency_sketches(self):
     if self.sketches != {}:

--- a/src/estimators/stratified_sketch.py
+++ b/src/estimators/stratified_sketch.py
@@ -179,15 +179,15 @@ class StratifiedSketch(SketchBase):
   def create_one_plus_sketch(self):
     """Create the 1+ sketch for this stratified sketch.
 
-       We support creation of 1+ sketch for 2 scenerios :
+       We support creation of 1+ sketch for 2 scenarios :
          1) 1+ sketch is created from the underlying exact set directly. Here we
          noise 1+ sketch with epsilon = (self.epsilon * self.epsilon_split).
 
          2) 1+ sketch is created from the union of all other frequencies. Here
          we noise 1+ sketch with epsilon = self.epsilon
 
-      These two scenerios are controlled with the epsilon_split parameter. If
-      epsilon_split = 0, then do scenerio 1 otherwise do scenerio 2.
+      These two scenarios are controlled with the epsilon_split parameter. If
+      epsilon_split = 0, then do scenario 1 otherwise do scenario 2.
     """
 
     if ONE_PLUS in self.sketches:

--- a/src/estimators/stratified_sketch.py
+++ b/src/estimators/stratified_sketch.py
@@ -29,7 +29,7 @@ class ExactSetOperator(object):
   The methods below all accept an ExactMultiSet object and returning an
   ExactMultiSet object.
   """
-
+  #   TODO(uakyol) : Make this child of SketchOperator class.
   @classmethod
   def union(cls, this, that):
     """Union operation for ExactSet."""
@@ -76,7 +76,7 @@ class StratifiedSketch(SketchBase):
                          max_freq,
                          cardinality_sketch_factory,
                          noiser_class=None,
-                         epsilon=0,
+                         epsilon=None,
                          epsilon_split=0.5,
                          underlying_set=None,
                          union=ExactSetOperator.union):
@@ -114,7 +114,9 @@ class StratifiedSketch(SketchBase):
         simulator.EstimatorConfig.sketch_factory.
       noiser : A noiser class that is a subclass of base.EstimateNoiserBase.
       epsilon : Total privacy budget to spend for noising this sketch.
-      epsilon_split : Ratio of privacy budget to spend to noise 1+ sketch.
+      epsilon_split : Ratio of privacy budget to spend to noise 1+ sketch. When
+        epsilon_split=0 the 1+ sketch is created from the underlying exact set
+        directly. epsilon_split should be smaller than 1.
       underlying_set : ExactMultiSet object that holds the frequency for each
         item for this Stratified Sketch.
       union : Function to be used to calculate the 1+ sketch as the union of the

--- a/src/estimators/tests/stratified_sketch_test.py
+++ b/src/estimators/tests/stratified_sketch_test.py
@@ -362,64 +362,66 @@ class PairwiseEstimatorTest(absltest.TestCase):
     expected = [6, 4, 3]
     self.assertEqual(estimated, expected)
 
-#   def test_end_to_end_noise_with_oneplus_budget(self):
-#     max_freq = 3
-#     this_multi_set = generate_multi_set([(1, 2), (2, 3), (3, 1), (10, 1)])
-#     that_multi_set = generate_multi_set([(1, 1), (3, 1), (4, 5), (5, 1)])
-#     this_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
-#         max_freq,
-#         this_multi_set,
-#         epsilon=0.8,
-#         epsilon_split=0.5,
-#         noiser_class=PlusNoiser,
-#         cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
-#         random_seed=1)
-#     that_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
-#         max_freq,
-#         that_multi_set,
-#         epsilon=0.8,
-#         epsilon_split=0.5,
-#         noiser_class=PlusNoiser,
-#         cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
-#         random_seed=1)
-#     estimator = stratified_sketch.PairwiseEstimator(
-#         denoiser_class=MinusDenoiser,
-#         sketch_operator=stratified_sketch.ExactSetOperator,
-#         cardinality_estimator=LosslessEstimator())
+  def test_end_to_end_noise_with_oneplus_budget(self):
+    max_freq = 3
+    this_multi_set = generate_multi_set([(1, 2), (2, 3), (3, 1), (10, 1)])
+    that_multi_set = generate_multi_set([(1, 1), (3, 1), (4, 5), (5, 1)])
+    this_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
+        max_freq,
+        this_multi_set,
+        epsilon=0.8,
+        epsilon_split=0.5,
+        noiser_class=PlusNoiser,
+        cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
+        random_seed=1)
+    that_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
+        max_freq,
+        that_multi_set,
+        epsilon=0.8,
+        epsilon_split=0.5,
+        noiser_class=PlusNoiser,
+        cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
+        random_seed=1)
+    estimator = stratified_sketch.PairwiseEstimator(
+        denoiser_class=MinusDenoiser,
+        sketch_operator=stratified_sketch.ExactSetOperator,
+        cardinality_estimator=LosslessEstimator())
 
-#     estimated = estimator(this_noised_sketch, that_noised_sketch)
-#     expected = [6, 4, 3]
-#     self.assertEqual(estimated, expected)
+    estimated = estimator(this_noised_sketch, that_noised_sketch)
+    expected = [6, 4, 3]
+    self.assertEqual(estimated, expected)
 
 
-#   def test_end_to_end_noise_without_oneplus_budget(self):
-#     max_freq = 3
-#     this_multi_set = generate_multi_set([(1, 2), (2, 3), (3, 1), (10, 1)])
-#     that_multi_set = generate_multi_set([(1, 1), (3, 1), (4, 5), (5, 1)])
-#     this_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
-#         max_freq,
-#         this_multi_set,
-#         epsilon=0.8,
-#         epsilon_split=0,
-#         noiser_class=PlusNoiser,
-#         cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
-#         random_seed=1)
-#     that_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
-#         max_freq,
-#         that_multi_set,
-#         epsilon=0.8,
-#         epsilon_split=0,
-#         noiser_class=PlusNoiser,
-#         cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
-#         random_seed=1)
-#     estimator = stratified_sketch.PairwiseEstimator(
-#         denoiser_class=MinusDenoiser,
-#         sketch_operator=stratified_sketch.ExactSetOperator,
-#         cardinality_estimator=LosslessEstimator())
+  def test_end_to_end_noise_without_oneplus_budget(self):
+    max_freq = 3
+    this_multi_set = generate_multi_set([(1, 2), (2, 3), (3, 1), (10, 1)])
+    that_multi_set = generate_multi_set([(1, 1), (3, 1), (4, 5), (5, 1)])
+    this_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
+        max_freq,
+        this_multi_set,
+        epsilon=0.8,
+        epsilon_split=0,
+        noiser_class=PlusNoiser,
+        union=stratified_sketch.ExactSetOperator.union,
+        cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
+        random_seed=1)
+    that_noised_sketch = stratified_sketch.StratifiedSketch.init_from_exact_multi_set(
+        max_freq,
+        that_multi_set,
+        epsilon=0.8,
+        epsilon_split=0,
+        noiser_class=PlusNoiser,
+        union=stratified_sketch.ExactSetOperator.union,
+        cardinality_sketch_factory=ExactMultiSet.get_sketch_factory(),
+        random_seed=1)
+    estimator = stratified_sketch.PairwiseEstimator(
+        denoiser_class=MinusDenoiser,
+        sketch_operator=stratified_sketch.ExactSetOperator,
+        cardinality_estimator=LosslessEstimator())
 
-#     estimated = estimator(this_noised_sketch, that_noised_sketch)
-#     expected = [6, 4, 3]
-#     self.assertEqual(estimated, expected)
+    estimated = estimator(this_noised_sketch, that_noised_sketch)
+    expected = [6, 4, 3]
+    self.assertEqual(estimated, expected)
 
 class SequentialEstimatorTest(absltest.TestCase):
   """Test SequentialEstimator merge and frequency estimation."""


### PR DESCRIPTION
Here is the second part of the stratified sketch where we introduce noising. We introduce a epsilon_split parameter to split the privacy budget into two parts:  For 1+ sketch and other sketches.

       We support creation of 1+ sketch for 2 scenerios :
         1) 1+ sketch is created from the underlying exact set directly. Here we
         noise 1+ sketch with epsilon = (self.epsilon * self.epsilon_split).

         2) 1+ sketch is created from the union of all other frequencies. Here
         we noise 1+ sketch with epsilon = self.epsilon

      These two scenarios are controlled with the epsilon_split parameter. If
      epsilon_split = 0, then do scenario 1 otherwise do scenario 2.