### PR TITLE
Remove pickle.

### DIFF
--- a/src/evaluations/tests/evaluator_test.py
+++ b/src/evaluations/tests/evaluator_test.py
@@ -137,28 +137,6 @@ class EvaluatorTest(absltest.TestCase):
         out_dir=out_dir)
     self.assertEqual(created, loaded)
 
-  def test_evaluate_all_generate_save_configs(self):
-    test_evaluator = self.get_test_evaluator(self.create_tempdir().full_path)
-    test_evaluator()
-    for sketch_estimator_config in self.sketch_estimator_config_list:
-      sketch_estimator_config_file = os.path.join(
-          test_evaluator.description_to_file_dir[
-              evaluator.KEY_ESTIMATOR_DIRS][sketch_estimator_config.name],
-          evaluator.ESTIMATOR_CONFIG_FILE)
-      self.assertTrue(
-          os.path.exists(sketch_estimator_config_file),
-          'Estimator config file doesn\'t exist: '
-          f'{sketch_estimator_config.name}')
-
-      for scenario_config in self.evaluation_config.scenario_config_list:
-        scenario_config_file = os.path.join(
-            test_evaluator.description_to_file_dir[
-                sketch_estimator_config.name][scenario_config.name],
-            evaluator.SCENARIO_CONFIG_FILE)
-        self.assertTrue(
-            os.path.exists(scenario_config_file),
-            f'Scenario config file doesn\'t exist: {scenario_config.name}')
-
   def test_evaluate_all_save_results(self):
     test_evaluator = self.get_test_evaluator(self.create_tempdir().full_path)
     test_evaluator()


### PR DESCRIPTION
Reasons to remove pickle:
1. It is not used by the output.
2. Pickle can only serialize the top level class and functions. And in this code base, we are using `factory` methods a lot, and it is easy to get errors. For example, the stratified sketch VoC and stratified sketch ADBF use sketch_factory, so they are not compatible with pickle. The error message looks like:
```
AttributeError: Can't pickle local object 'VectorOfCounts.get_sketch_factory.<locals>.f'
```
where `<locals>` is a class referred by the `get_sketch_factory` method.