### PR TITLE
Bug fix for report generator

### DIFF
--- a/src/evaluations/report_generator.py
+++ b/src/evaluations/report_generator.py
@@ -207,18 +207,20 @@ class ReportGenerator:
     assert analysis_type in (ANALYSIS_TYPE_CARDINALITY,
                              ANALYSIS_TYPE_FREQUENCY)
 
-    sketch_estimator_df = pd.DataFrame(
-        [], columns=evaluation_configs.SKETCH_ESTIMATOR_CONFIG_NAMES_FORMAT)
+    parsed_colnames = list(evaluation_configs
+                           .SKETCH_ESTIMATOR_CONFIG_NAMES_FORMAT)
+    if analysis_type == ANALYSIS_TYPE_CARDINALITY:
+      parsed_colnames = [colname for colname in parsed_colnames
+                         if colname != evaluation_configs.MAX_FREQUENCY]
+
+    sketch_estimator_df = pd.DataFrame([], columns=parsed_colnames)
     for sketch_estimator in sketch_estimator_list:
       sketch_estimator_df = sketch_estimator_df.append(
           ReportGenerator.parse_sketch_estimator_name(sketch_estimator),
           ignore_index=True)
 
     def _generate_plots_html(row):
-      sketch_estimator_name = '-'.join([
-          str(row[i]) for i in (
-              evaluation_configs.SKETCH_ESTIMATOR_CONFIG_NAMES_FORMAT)
-      ])
+      sketch_estimator_name = '-'.join([str(row[i]) for i in parsed_colnames])
       if sketch_estimator_name not in description_to_file_dir[
           evaluator.KEY_ESTIMATOR_DIRS]:
         return None


### PR DESCRIPTION
Fix for plot link missing due to wrong sketch estimator name.

The bug is from the difference of the sketch_estimator name of the cardinality estimator and the frequency estimator. The previous code will attach -nan to the sketch_estimator name, and that name will not be found in the directory tree. So this PR  does the following:
1. Fix this bug by checking the analysis type.
2. Add testing for plot file link in the HTML file.