### PR TITLE
Add stratified sketch based on exp-ADBF.

### DIFF
--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -432,6 +432,16 @@ class EvaluationConfigTest(parameterized.TestCase):
         'exp_same_key_aggregator-100_10-standardized_histogram'
         '-no_local_dp-global_dp_1.0000-3')
 
+  def test_stratiefied_sketch_exp_adbf(self):
+    conf = evaluation_configs._stratiefied_sketch_exponential_adbf(
+        max_frequency=3, length=100, sketch_epsilon=1, global_epsilon=1)
+    self.assertEqual(conf.max_frequency, 3)
+    self.assertEqual(
+        conf.name,
+        'stratified_sketch_exp_adbf-100_10'
+        '-first_moment_estimator_exp_expectation'
+        '-local_dp_1.0000-global_dp_1.0000-3')
+
 
 if __name__ == '__main__':
   absltest.main()


### PR DESCRIPTION
Note: the current smoke test eval for the stratified ADBF will return error messages. We are investigating the issue.

Example run with the following command line script:
```
K_OUTPUT_DIR_FREQ="tmp_output_directory"
K_NUM_RUNS=10

python3 src/evaluations/run_evaluation.py \
--evaluation_out_dir="$K_OUTPUT_DIR_FREQ" \
--analysis_out_dir="$K_OUTPUT_DIR_FREQ" \
--report_out_dir="$K_OUTPUT_DIR_FREQ" \
--evaluation_config="frequency_smoke_test" \
--sketch_estimator_configs="stratified_sketch_exp_adbf-100000_10-first_moment_estimator_exp_expectation-no_local_dp-no_global_dp-5" \
--evaluation_run_name="simple_run" \
--analysis_type="frequency" \
--num_workers=0 \
--num_runs=$K_NUM_RUNS \
--max_frequency=5 \
--error_margin="0.1,0.1" \
--proportion_of_runs="0.9,0.95" \
--run_evaluation=True \
--run_analysis=True \
--generate_html_report=False
```