### PR TITLE
update HLL++ to use sparse mode

### DIFF
--- a/src/estimators/hyper_log_log.py
+++ b/src/estimators/hyper_log_log.py
@@ -28,8 +28,10 @@ class HyperLogLogPlusPlus(SketchBase):
   """HyperLogLogPlusPlus Sketch.
 
   More accurately referred to as HyperLogLogPartialPlusPlus.  We do not
-  implement several of the ++ improvements, namely bias estimation and sparse
-  mode.  Also technically has to be 64 bits to be ++, but for testing and
+  implement several of the ++ improvements, namely bias estimation and our sparse
+  mode is much simpler at the cost of using extra memory.
+  
+  Also technically has to be 64 bits to be ++, but for testing and
   experimentation purposes, we allow changing the number of bits here.
 
   Paper reference can be found here:
@@ -120,6 +122,10 @@ class HyperLogLogPlusPlus(SketchBase):
     # Int to get the p most significant bits
     self._idx_helper_int = int(
         '1' * self.log2_vector_length_p + '0' * self.num_bucket_bits, 2)
+    
+    # Items for our simpler version of sparse mode:
+    self.sparse_mode = True
+    self.temp_set = set()
 
   def assert_compatible(self, other):
     """Performs check on other to make sure its compatible with self."""
@@ -149,6 +155,16 @@ class HyperLogLogPlusPlus(SketchBase):
     return self._count_leading_zeros(w) + 1
 
   def add(self, value):
+    # Handle sparse mode first if needed
+    if self.sparse_mode:
+      self.temp_set.add(value)
+      # Check if we're at the threshold yet for normal mode
+      if len(self.temp_set) > self.vector_length_m * 6:
+        self.sparse_mode = False
+        self.temp_set.clear()
+    
+    # Then do normal HLL calculation no matter if sparse mode is on
+    # (another simplification we made from the paper at the cost of memory)
     hash_value = self.my_hasher(value)
 
     bucket_index = self.get_idx_bits(hash_value)
@@ -173,9 +189,11 @@ class HyperLogLogPlusPlus(SketchBase):
   def estimate_cardinality(self):
     """Returns the estimated cardinality of this sketch.
 
-    Note we have decided not to implement the bias estimate or sparse mode for
-    small numbers of added items.
+    Note we have decided not to implement the bias estimate for now.
     """
+    if self.sparse_mode:
+      return len(self.temp_set)
+      
     raw_estimate_e = self._raw_hll_cardinality_estimate()
 
     if raw_estimate_e <= 5 * self.vector_length_m:
@@ -212,6 +230,19 @@ class HyperLogLogPlusPlus(SketchBase):
 
     output_hll = copy.deepcopy(other_hll)
     output_hll.buckets = np.max([self.buckets, output_hll.buckets], axis=0)
+    
+    # Handle sparse mode merging:
+    output_hll.sparse_mode = output_hll.sparse_mode and self.sparse_mode
+    if output_hll.sparse_mode:
+      output_hll.temp_set = output_hll.temp_set.union(self.temp_set)
+      # To cover the case where the new HLL shouldn't be in sparse mode, pop a
+      # random item from the set and add it back to trigger the check
+      if len(output_hll.temp_set) > 0:
+        random_item = output_hll.temp_set.pop()
+        output_hll.add(random_item)
+    else:
+      output_hll.temp_set = set()
+    
     return output_hll
 
 

--- a/src/estimators/hyper_log_log.py
+++ b/src/estimators/hyper_log_log.py
@@ -28,9 +28,9 @@ class HyperLogLogPlusPlus(SketchBase):
   """HyperLogLogPlusPlus Sketch.
 
   More accurately referred to as HyperLogLogPartialPlusPlus.  We do not
-  implement several of the ++ improvements, namely bias estimation and our sparse
-  mode is much simpler at the cost of using extra memory.
-  
+  implement several of the ++ improvements, namely bias estimation and our
+  sparse mode is much simpler at the cost of using extra memory.
+
   Also technically has to be 64 bits to be ++, but for testing and
   experimentation purposes, we allow changing the number of bits here.
 
@@ -122,7 +122,7 @@ class HyperLogLogPlusPlus(SketchBase):
     # Int to get the p most significant bits
     self._idx_helper_int = int(
         '1' * self.log2_vector_length_p + '0' * self.num_bucket_bits, 2)
-    
+
     # Items for our simpler version of sparse mode:
     self.sparse_mode = True
     self.temp_set = set()
@@ -162,7 +162,7 @@ class HyperLogLogPlusPlus(SketchBase):
       if len(self.temp_set) > self.vector_length_m * 6:
         self.sparse_mode = False
         self.temp_set.clear()
-    
+
     # Then do normal HLL calculation no matter if sparse mode is on
     # (another simplification we made from the paper at the cost of memory)
     hash_value = self.my_hasher(value)
@@ -193,7 +193,7 @@ class HyperLogLogPlusPlus(SketchBase):
     """
     if self.sparse_mode:
       return len(self.temp_set)
-      
+
     raw_estimate_e = self._raw_hll_cardinality_estimate()
 
     if raw_estimate_e <= 5 * self.vector_length_m:
@@ -230,19 +230,19 @@ class HyperLogLogPlusPlus(SketchBase):
 
     output_hll = copy.deepcopy(other_hll)
     output_hll.buckets = np.max([self.buckets, output_hll.buckets], axis=0)
-    
+
     # Handle sparse mode merging:
     output_hll.sparse_mode = output_hll.sparse_mode and self.sparse_mode
     if output_hll.sparse_mode:
       output_hll.temp_set = output_hll.temp_set.union(self.temp_set)
       # To cover the case where the new HLL shouldn't be in sparse mode, pop a
       # random item from the set and add it back to trigger the check
-      if len(output_hll.temp_set) > 0:
+      if output_hll.temp_set:
         random_item = output_hll.temp_set.pop()
         output_hll.add(random_item)
     else:
       output_hll.temp_set = set()
-    
+
     return output_hll
 
 

--- a/src/estimators/tests/hyper_log_log_test.py
+++ b/src/estimators/tests/hyper_log_log_test.py
@@ -181,7 +181,7 @@ class HyperLogLogPlusPlusEstimatorTest(absltest.TestCase):
   def test_estimator_large(self):
     self.estimator_tester_helper(100_000)
 
-  def test_estimator_cardinality(self):
+  def test_estimator_cardinality_sparse_mode(self):
     estimator = HllCardinality()
     for truth in [0, 1, 1024]:
       hll = HyperLogLogPlusPlus(random_seed=89, length=1024)
@@ -189,6 +189,15 @@ class HyperLogLogPlusPlusEstimatorTest(absltest.TestCase):
         hll.add(i)
       estimated = estimator([hll])[0]
       self.assertEqual(estimated, truth)
+
+  def test_estimator_cardinality_dense_mode(self):
+    estimator = HllCardinality()
+    for truth in [1025, 2048]:
+      hll = HyperLogLogPlusPlus(random_seed=89, length=1024)
+      for i in range(truth):
+        hll.add(i)
+      estimated = estimator([hll])[0]
+      self.assertAlmostEqual(estimated, truth, delta=truth * 0.05)
 
 
 if __name__ == '__main__':

--- a/src/estimators/tests/hyper_log_log_test.py
+++ b/src/estimators/tests/hyper_log_log_test.py
@@ -167,7 +167,10 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
                     'Merged sketch is not in sparse mode.')
     self.assertTrue(all(hll1.buckets == merged_hll.buckets),
                     'Merged sketch is not correct.')
-    self.assertSameElements(hll1.temp_set, set([1]), 'Temp set is not correct.')
+    self.assertSameElements(merged_hll.temp_set, set([1]),
+                            'Temp set is not correct.')
+    self.assertEqual(merged_hll.estimate_cardinality(), 1,
+                     'Estimated cardinality is not correct.')
 
   def test_merge_sparse_with_sparse_to_dense(self):
     hll1 = HyperLogLogPlusPlus(length=16, random_seed=234)
@@ -179,6 +182,8 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
     merged_hll = hll1.merge(hll2)
     self.assertTrue(merged_hll.sparse_mode,
                     'Merged sketch should be in sparse mode.')
+    self.assertEqual(merged_hll.estimate_cardinality(), 96,
+                     'Estimated cardinality not correct under sparse mode.')
 
     hll1.add(1000)
     merged_hll = hll1.merge(hll2)

--- a/src/estimators/tests/hyper_log_log_test.py
+++ b/src/estimators/tests/hyper_log_log_test.py
@@ -104,6 +104,7 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
 
     one_vector = np.ones(self.vector_length)
     hll.buckets = one_vector
+    hll.sparse_mode = False
     alpha_16 = 0.673
     hll_should_estimate = alpha_16 * self.vector_length**2 * 2 / self.vector_length
 
@@ -119,6 +120,7 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
 
     thirty_vector = 30 * np.ones(m)
     hll.buckets = thirty_vector
+    hll.sparse_mode = False
     alpha_m = 0.7213 / (1 + 1.079 / m)
     hll_should_estimate = alpha_m * m**2 * 2**30 / m
 
@@ -178,6 +180,15 @@ class HyperLogLogPlusPlusEstimatorTest(absltest.TestCase):
 
   def test_estimator_large(self):
     self.estimator_tester_helper(100_000)
+
+  def test_estimator_cardinality(self):
+    estimator = HllCardinality()
+    for truth in [0, 1, 1024]:
+      hll = HyperLogLogPlusPlus(random_seed=89, length=1024)
+      for i in range(truth):
+        hll.add(i)
+      estimated = estimator([hll])[0]
+      self.assertEqual(estimated, truth)
 
 
 if __name__ == '__main__':

--- a/src/estimators/tests/hyper_log_log_test.py
+++ b/src/estimators/tests/hyper_log_log_test.py
@@ -189,6 +189,10 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
     merged_hll = hll1.merge(hll2)
     self.assertFalse(merged_hll.sparse_mode,
                      'Merged sketch should not be in sparse mode.')
+    self.assertAlmostEqual(
+        merged_hll.estimate_cardinality(), 97, delta=97 * 0.05,
+        msg='Estimated cardinality not correct under dense mode.'
+    )
 
   def test_merge_sparse_with_dense(self):
     hll1 = HyperLogLogPlusPlus(length=16, random_seed=234)
@@ -205,6 +209,8 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
                      'Merged sketch is not correct.')
     self.assertSameElements(merged_hll.temp_set, set(),
                             'Temp set is not correct.')
+    self.assertGreater(merged_hll.estimate_cardinality(),
+                       hll2.estimate_cardinality())
 
   def test_merge_dense_with_dense(self):
     hll1 = HyperLogLogPlusPlus(length=16, random_seed=234)
@@ -220,6 +226,9 @@ class HyperLogLogPlusPlusTest(absltest.TestCase):
                        'Merged sketch is not correct.')
     self.assertSameElements(merged_hll.temp_set, set(),
                             'Temp set is not correct.')
+    self.assertAlmostEqual(
+        merged_hll.estimate_cardinality(), 194, delta=194 * 0.1
+        )
 
 
 class HyperLogLogPlusPlusEstimatorTest(absltest.TestCase):


### PR DESCRIPTION
HLL++ doesn't do well for small cardinalities so we are updating our implementation to use a version of sparse mode from the HLL++ paper, that doesn't care so much about memory space but is much simpler to implement.

Note this is not tested.