### PR TITLE
Add config for Meta VoC estimator for Bloom Filters.

### DIFF
--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -435,6 +435,22 @@ class EvaluationConfigTest(parameterized.TestCase):
     voc_sketch = conf.estimator.meta_sketch_factory(1)
     self.assertLen(voc_sketch.stats, 4)
 
+  def test_meta_voc_for_bf(self):
+    conf = evaluation_configs._meta_voc_for_bf(
+        bf_length=16,
+        voc_length=4,
+        sketch_epsilon=1)
+    self.assertEqual(
+        conf.name,
+        'bloom_filter-16-meta_voc_4-local_dp_1.0000-no_global_dp',
+        'Config name is not correct.')
+    bf = conf.sketch_factory(1)
+    self.assertLen(bf.sketch, 16)
+    bf.add(1)
+    self.assertAlmostEqual(conf.estimator([bf])[0], 1.03, delta=1.03 * 0.1)
+    voc_sketch = conf.estimator.meta_sketch_factory(1)
+    self.assertLen(voc_sketch.stats, 4)
+
   def test_get_estimator_configs_return_configs(self):
     expected_sketch_estimator_configs = [conf.name for conf in (
         evaluation_configs._generate_cardinality_estimator_configs())]


### PR DESCRIPTION
Example run through:
```
K_NUM_RUNS=10
K_OUT_DIR="your_output_directory"

python3 src/evaluations/run_evaluation.py \
--evaluation_out_dir="$K_OUT_DIR" \
--analysis_out_dir="$K_OUT_DIR" \
--report_out_dir="$K_OUT_DIR" \
--evaluation_config="smoke_test" \
--sketch_estimator_configs="bloom_filter-5000000-meta_voc_4096-local_dp_1.0986-no_global_dp" \
--sketch_estimator_configs="bloom_filter-5000000-meta_voc_4096-no_local_dp-no_global_dp" \
--evaluation_run_name="results" \
--num_runs=$K_NUM_RUNS \
--error_margin="0.05,0.1" \
--proportion_of_runs="0.95,0.95" \
--run_evaluation=True \
--run_analysis=True \
--generate_html_report=True
```