### PR TITLE
[Part 1 Liquid Legion Global DP tests]Add disjoint set generator.

### DIFF
--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -57,6 +57,10 @@ LARGE_REACH_RATE_SMOKE_TEST = 0.2
 SMALL_REACH_RATE_VALUE = 0.01
 LARGE_REACH_RATE_VALUE = 0.2
 
+# Global DP stress test.
+US_INTERNET_POPULATION = 2_000_000_000
+REACH_STRESS_TEST = [1_000, 10_000, 100_000, 1_000_000, 10_000_000, 100_000_000]
+
 # Frequency test reach percent.
 REACH_RATE_FREQ_END_TO_END_TEST = 0.1
 REACH_RATE_FREQ_SMOKE_TEST = 0.1
@@ -80,7 +84,10 @@ SKETCH_EPSILON_VALUES = (math.log(3), math.log(3) / 4, math.log(3) / 10, None)
 # mimic the global differential privacy use case. In the real world, the
 # implementation could be different and more complicated.
 # As such, we use a small epsilon so as to be conservative on the result.
-ESTIMATE_EPSILON_VALUES = (math.log(3), None)
+ESTIMATE_EPSILON_VALUES = [
+    math.log(3) / x for x in [
+        1, 2, 4, 10, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000]
+] + [None]
 
 # The length of the Any Distribution Bloom Filters.
 # We use the np.array with dtype so as to make sure that the lengths are all
@@ -703,6 +710,26 @@ def _complete_test_with_selected_parameters(
       scenario_config_list=scenario_config_list)
 
 
+def _stress_test_cardinality_global_dp(universe_size=None,
+                                       num_runs=NUM_RUNS_VALUE):
+  """Stress test for cardinality estimator under global DP."""
+  # The universe_size argument is included to conform to the run_evaluation
+  # module.
+  _ = universe_size
+  scenario_config_list = []
+  for scenario_id, reach in enumerate(sorted(REACH_STRESS_TEST)):
+    scenario_config_list.append(ScenarioConfig(
+        name=f'{scenario_id}-reach:{reach}',
+        set_generator_factory=(
+            set_generator.DisjointSetGenerator
+            .get_generator_factory_with_set_size_list(
+                set_sizes=[reach]))))
+  return EvaluationConfig(
+      name='global_dp_stress_test',
+      num_runs=num_runs,
+      scenario_config_list=scenario_config_list)
+
+
 def _frequency_end_to_end_test(universe_size=10000, num_runs=NUM_RUNS_VALUE):
   """EvaluationConfig of end-to-end test of frequency evaluation code."""
   num_sets = 3
@@ -734,6 +761,7 @@ def _generate_evaluation_configs():
   return (
       _smoke_test,
       _complete_test_with_selected_parameters,
+      _stress_test_cardinality_global_dp,
       _frequency_end_to_end_test,
       _frequency_smoke_test,
       _complete_frequency_test_with_selected_parameters,

--- a/src/evaluations/data/tests/evaluation_configs_test.py
+++ b/src/evaluations/data/tests/evaluation_configs_test.py
@@ -20,6 +20,7 @@ import numpy as np
 
 from wfa_cardinality_estimation_evaluation_framework.evaluations import configs
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data import evaluation_configs
+from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import _stress_test_cardinality_global_dp
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import _complete_test_with_selected_parameters
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import GLOBAL_DP_STR
 from wfa_cardinality_estimation_evaluation_framework.evaluations.data.evaluation_configs import LOCAL_DP_STR
@@ -344,6 +345,17 @@ class EvaluationConfigTest(parameterized.TestCase):
     eval_configs = _complete_test_with_selected_parameters(num_runs=1)
     for scenario_config in eval_configs.scenario_config_list:
       self.assertIsInstance(scenario_config, configs.ScenarioConfig)
+
+  def test_cardinality_global_dp_stress_test(self):
+    eval_configs = _stress_test_cardinality_global_dp(
+        universe_size=None, num_runs=1)
+    for scenario_config in eval_configs.scenario_config_list:
+      self.assertIsInstance(scenario_config, configs.ScenarioConfig)
+      gen = scenario_config.set_generator_factory(np.random.RandomState(0))
+      reach = float(scenario_config.name.split('-')[1].lstrip('reach:'))
+      set_ids_list = [set_ids for set_ids in gen]
+      self.assertLen(set_ids_list, 1)
+      self.assertLen(set_ids_list[0], reach)
 
   @parameterized.parameters(
       (LOCAL_DP_STR, None, NO_LOCAL_DP_STR),

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -523,8 +523,8 @@ class DisjointSetGenerator(SetGeneratorBase):
 
   def __iter__(self):
     for set_size in self.set_sizes:
-      set_ids = np.arange(self.start_id, self.start_id + set_size, dtype=int)
-      self.union_ids = self.union_ids.union(set_ids)
+      set_ids = range(self.start_id, self.start_id + set_size)
+      self.union_ids = range(self.start_id+set_size)
       self.start_id += set_size
       yield set_ids
     return self

--- a/src/simulations/set_generator.py
+++ b/src/simulations/set_generator.py
@@ -486,3 +486,45 @@ class SequentiallyCorrelatedSetGenerator(SetGeneratorBase):
       yield set_ids_list[i]
     return self
 
+
+class DisjointSetGenerator(SetGeneratorBase):
+  """Disjoint set generator.
+
+  This set generator can be used to
+  (1) evaluate cardinality estimators under the disjoint scenario,
+  (2) fast test the relative error of the estimates, as it is a deterministic
+    algorithm, and hence is fast.
+  """
+
+  @classmethod
+  def get_generator_factory_with_set_size_list(cls, set_sizes):
+    def _f(random_state):
+      return cls(set_sizes, random_state)
+    return _f
+
+  @classmethod
+  def get_generator_factory_with_num_and_size(cls, num_sets, set_size):
+    def _f(random_state):
+      return cls(_SetSizeGenerator(num_sets, set_size), random_state)
+    return _f
+
+  def __init__(self, set_sizes, random_state=None):
+    """Create a disjoint set generator.
+
+    Args:
+      set_sizes: an iterable of the set sizes.
+      random_state: a numpy random state instance. It is not used, but only to
+        conform to the set generator constructor arguments.
+    """
+    self.union_ids = set()
+    _ = random_state
+    self.set_sizes = set_sizes
+    self.start_id = 0
+
+  def __iter__(self):
+    for set_size in self.set_sizes:
+      set_ids = np.arange(self.start_id, self.start_id + set_size, dtype=int)
+      self.union_ids = self.union_ids.union(set_ids)
+      self.start_id += set_size
+      yield set_ids
+    return self

--- a/src/simulations/tests/set_generator_test.py
+++ b/src/simulations/tests/set_generator_test.py
@@ -54,6 +54,7 @@ class SetGeneratorTest(parameterized.TestCase):
        {'order': 'reversed', 'correlated_sets': 'one', 'shared_prop': 0.2}),
       (set_generator.SequentiallyCorrelatedSetGenerator,
        {'order': 'random', 'correlated_sets': 'one', 'shared_prop': 0.2}),
+      (set_generator.DisjointSetGenerator, {}),
       (frequency_set_generator.HomogeneousMultiSetGenerator,
        {'universe_size': TEST_UNIVERSE_SIZE,
         'freq_rates': np.ones_like(TEST_SET_SIZE_LIST), 'freq_cap': 2}),
@@ -457,6 +458,14 @@ class SetGeneratorTest(parameterized.TestCase):
     self.assertLen(np.intersect1d(set_ids_list[0], set_ids_list[1]),
                    1,
                    f'{correlation_type}: Overlap set size not correct.')
+
+  def test_disjoint_set_generator(self):
+    gen = set_generator.DisjointSetGenerator(set_sizes=[1, 2])
+    set_ids_list = [set_ids for set_ids in gen]
+    expected = [np.array(ids) for ids in [[0], [1, 2]]]
+    self.assertEqual(len(set_ids_list), len(expected))
+    for x, y in zip(set_ids_list, expected):
+      self.assertTrue(all(x == y))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This chain of PRs is to test the limit of liquid legions under different epsilon * audience sizes combinations.

This PR is to add a disjoint set generator which is a deterministic so that the simulation could be much faster.