### PR TITLE
Initial commit for GaussianEstimateNoiser

### DIFF
--- a/src/common/noisers.py
+++ b/src/common/noisers.py
@@ -44,10 +44,7 @@ class LaplaceMechanism:
     self._func = f
     self._delta_f = delta_f
     self._epsilon = epsilon
-    if random_state:
-      self._random_state = random_state
-    else:
-      self._random_state = np.random.RandomState()
+    self._random_state = random_state or np.random.RandomState()
 
   def __call__(self, x):
     z = self._func(x)
@@ -103,10 +100,7 @@ class GeometricMechanism:
     self._func = f
     self._delta_f = delta_f
     self._epsilon = epsilon
-    if random_state:
-      self._random_state = random_state
-    else:
-      self._random_state = np.random.RandomState()
+    self._random_state = random_state or np.random.RandomState()
 
   def __call__(self, x):
     z = self._func(x)
@@ -152,10 +146,7 @@ class GaussianMechanism:
     # Set the standard deviation sigma, following Appendix A of Dwork and Roth.
     self._sigma = (math.sqrt(2 * math.log(1.25 / delta)) * delta_f *
       math.sqrt(num_queries) / epsilon)
-    if random_state:
-      self._random_state = random_state
-    else:
-      self._random_state = np.random.RandomState()
+    self._random_state = random_state or np.random.RandomState()
 
   def __call__(self, x):
     z = self._func(x)

--- a/src/common/noisers.py
+++ b/src/common/noisers.py
@@ -116,6 +116,52 @@ class GeometricMechanism:
     return z + x - y
 
 
+class GaussianMechanism:
+  """Transforms a function using the gaussian mechanism.
+
+  If f(x) = (Z[1], Z[2], ..., Z[k]), then returns a function that computes
+  (Z'[1], Z'[2], ..., Z'[k]), where
+      Z'[i] = Z[i] + Y[i],
+      Y[i] ~ N(x | sigma),
+  and N(x | sigma) is given by the probability density function
+      N(x | sigma) = exp(-0.5 x^2 / sigma^2) / (sigma * sqrt(2 * pi))
+
+  See Appendix A of Dwork and Roth.
+  """
+
+  def __init__(
+    self, f, delta_f, epsilon, delta, num_queries=1, random_state=None):
+    """Instantiates a gaussian mechanism.
+
+    Args:
+      f: A function which takes as input a database and which returns as output
+        a numpy array.
+      delta_f: The sensitivity paramater, e.g., the maximum value by which the
+        function can change for two databases that differ by only one row.
+      epsilon: Differential privacy parameter.
+      delta: Differential privacy paramter.
+      num_queries: The number of queries for which the mechanism is used. Note
+        that the constructed mechanism will be (epsilon, delta)-differentially
+        private when answering (no more than) num_queries queries.
+      random_state:  Optional instance of numpy.random.RandomState that is
+        used to seed the random number generator.
+    """
+    self._func = f
+    self._delta_f = delta_f
+    # TODO(pasin30055): Use tight computation of sigma.
+    # Set the standard deviation sigma, following Appendix A of Dwork and Roth.
+    self._sigma = (math.sqrt(2 * math.log(1.25 / delta)) * delta_f *
+      math.sqrt(num_queries) / epsilon)
+    if random_state:
+      self._random_state = random_state
+    else:
+      self._random_state = np.random.RandomState()
+
+  def __call__(self, x):
+    z = self._func(x)
+    return z + self._random_state.normal(size=z.shape, scale=self._sigma)
+
+
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')

--- a/src/common/tests/noisers_test.py
+++ b/src/common/tests/noisers_test.py
@@ -25,6 +25,14 @@ class FakeGeometricRandomState:
     self.calls_count += 1
     return self.return_values[self.calls_count - 1]
 
+class FakeGaussianRandomState:
+
+  def __init__(self, return_value):
+    self.return_value = return_value
+
+  def normal(self, size, scale):
+    return self.return_value
+
 
 class NoisersTest(absltest.TestCase):
 
@@ -35,7 +43,8 @@ class NoisersTest(absltest.TestCase):
 
   def test_laplace_mechanism_adds_expected_noise(self):
     rs = FakeLaplaceRandomState(np.array([2., 4., 6.]))
-    lm = noisers.LaplaceMechanism(lambda x: np.array([1., 2., 3.]), 1., 2., rs)
+    lm = noisers.LaplaceMechanism(lambda x: np.array([1., 2., 3.]), 1., 2.,
+                                  random_state=rs)
     result = lm(5.)
     np.testing.assert_array_equal(result, np.array([3., 6., 9.]))
 
@@ -64,7 +73,7 @@ class NoisersTest(absltest.TestCase):
   def test_geometric_mechanism_adds_expected_noise(self):
     rs = FakeGeometricRandomState(np.array([[3., 6., 13.], [1., 2., 7.]]))
     lm = noisers.GeometricMechanism(lambda x: np.array([1., 2., 3.]), 1., 2.,
-                                    rs)
+                                    random_state=rs)
     result = lm(5.)
     np.testing.assert_array_equal(result, np.array([3., 6., 9.]))
 
@@ -82,6 +91,37 @@ class NoisersTest(absltest.TestCase):
         random_state=np.random.RandomState(seed=125))
     result1 = lm1(5.)
     self.assertAlmostEqual(list(result0), list(result1))
+    result2 = lm1(5.)
+    self.assertNotEqual(list(result1), list(result2))
+
+  def test_gaussian_mechanism_works_with_scipy_stats_normal(self):
+    lm = noisers.GaussianMechanism(lambda x: np.array([1., 2., 3.]), 1., 2., .1)
+    result = lm(5.)
+    self.assertLen(result, 3)
+
+  def test_gaussian_mechanism_adds_expected_noise(self):
+    rs = FakeGaussianRandomState(np.array([2., 4., 6.]))
+    lm = noisers.GaussianMechanism(
+        lambda x: np.array([1., 2., 3.]), 1., 2., .1, random_state=rs)
+    result = lm(5.)
+    np.testing.assert_array_equal(result, np.array([3., 6., 9.]))
+
+  def test_gaussian_mechanism_respects_random_state(self):
+    lm0 = noisers.GaussianMechanism(
+        lambda x: np.array([1., 2., 3.]),
+        1.,
+        2.,
+        .1,
+        random_state=np.random.RandomState(seed=123))
+    result0 = lm0(5.)
+    lm1 = noisers.GaussianMechanism(
+        lambda x: np.array([1., 2., 3.]),
+        1.,
+        2.,
+        .1,
+        random_state=np.random.RandomState(seed=123))
+    result1 = lm1(5.)
+    self.assertEqual(list(result0), list(result1))
     result2 = lm1(5.)
     self.assertNotEqual(list(result1), list(result2))
 

--- a/src/estimators/estimator_noisers.py
+++ b/src/estimators/estimator_noisers.py
@@ -32,7 +32,7 @@ class LaplaceEstimateNoiser(base.EstimateNoiserBase):
     """
     # Note that any cardinality estimator will have sensitivity (delta_f) of 1.
     self._noiser = noisers.LaplaceMechanism(lambda x: x, 1.0, epsilon,
-                                            random_state)
+                                            random_state=random_state)
 
   def __call__(self, cardinality_estimate):
     """Returns a cardinality estimate with Laplace noise."""
@@ -55,10 +55,34 @@ class GeometricEstimateNoiser(base.EstimateNoiserBase):
     """
     # Note that any cardinality estimator will have sensitivity (delta_f) of 1.
     self._noiser = noisers.GeometricMechanism(lambda x: x, 1.0, epsilon,
-                                              random_state)
+                                              random_state=random_state)
 
   def __call__(self, cardinality_estimate):
-    """Returns a cardinality estimate with Laplace noise."""
+    """Returns a cardinality estimate with discrete Laplace noise."""
+    if type(cardinality_estimate) == float:
+      return self._noiser(np.array([cardinality_estimate]))[0]
+    else:
+      return self._noiser(cardinality_estimate)
+
+
+class GaussianEstimateNoiser(base.EstimateNoiserBase):
+  """A noiser that adds Gaussian noise to a cardinality estimate."""
+
+  def __init__(self, epsilon, delta, random_state=None):
+    """Instantiates a GaussianEstimateNoiser object.
+
+    Args:
+      epsilon:  The differential privacy level.
+      delta:  The differential privacy level.
+      random_state:  Optional instance of numpy.random.RandomState that is used
+        to seed the random number generator.
+    """
+    # Note that any cardinality estimator will have sensitivity (delta_f) of 1.
+    self._noiser = noisers.GaussianMechanism(
+      lambda x: x, 1.0, epsilon, delta, random_state=random_state)
+
+  def __call__(self, cardinality_estimate):
+    """Returns a cardinality estimate with Gaussian noise."""
     if type(cardinality_estimate) == float:
       return self._noiser(np.array([cardinality_estimate]))[0]
     else:

--- a/src/estimators/tests/estimator_noisers_test.py
+++ b/src/estimators/tests/estimator_noisers_test.py
@@ -26,6 +26,14 @@ class FakeGeometricRandomState:
     self.calls_count += 1
     return self.return_values[self.calls_count - 1]
 
+class FakeGaussianRandomState:
+
+  def __init__(self, return_value):
+    self.return_value = np.array(return_value)
+
+  def normal(self, size, scale):
+    return self.return_value
+
 
 class EstimatorNoisersTest(absltest.TestCase):
 
@@ -52,6 +60,18 @@ class EstimatorNoisersTest(absltest.TestCase):
         1.0, random_state=FakeGeometricRandomState([[3., -2.], [2., -1.]]))
     result = le(np.array([10., 20.]))
     np.testing.assert_array_equal(result, [11, 19])
+
+  def test_gaussian_estimate_noiser_accepts_scalar_argument(self):
+    le = estimator_noisers.GaussianEstimateNoiser(
+        1., .1, random_state=FakeGaussianRandomState([0.5]))
+    result = le(10.)
+    self.assertEqual(result, 10.5)
+
+  def test_gaussian_estimate_noiser_accepts_array_argument(self):
+    le = estimator_noisers.GaussianEstimateNoiser(
+        1., .1, random_state=FakeGaussianRandomState([0.5, -0.5]))
+    result = le(np.array([10., 20.]))
+    np.testing.assert_array_equal(result, [10.5, 19.5])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement GaussianMechanism and GeometricEstimateNoiser, which add Gaussian noise to a function/estimator to ensure differential privacy.

Note: currently the noise is calculated using a bound from Dwork-Roth book which is only valid for epsilon no more than one. A TODO is added to use a more accurate computation of sigma, which is also valid for all ranges of epsilon and delta.