### PR TITLE
[Part 2]Fix bug: Remove incompatible estimator noiser for the HLL.

### DIFF
--- a/src/estimators/bloom_filters.py
+++ b/src/estimators/bloom_filters.py
@@ -384,7 +384,9 @@ class FirstMomentEstimator(EstimatorBase):
     """Estimate cardinality of a Uniform Bloom Filter."""
     x = noiser(sum(sketch.sketch))
     m = len(sketch.sketch)
-    return - m * math.log(1 - x / m)
+    if x >= m or x < 0:
+      return float("NaN")
+    return -m * math.log(1 - x / m)
 
   @classmethod
   def _estimate_cardinality_log(cls, sketch, noiser):

--- a/src/estimators/tests/bloom_filters_test.py
+++ b/src/estimators/tests/bloom_filters_test.py
@@ -271,6 +271,17 @@ class FirstMomentEstimatorTest(parameterized.TestCase):
     estimate = estimator([adbf])[0]
     self.assertAlmostEqual(estimate, truth, 3, msg=method)
 
+  def test_uniform_bf_corner_cases(self):
+    adbf = UniformBloomFilter(length=2, random_seed=0)
+    # Test if the sketch is full.
+    adbf.sketch = np.array([1, 1])
+    estimator = FirstMomentEstimator(method='uniform')
+    self.assertTrue(math.isnan(estimator([adbf])[0]))
+    # Test if the register is negative.
+    adbf.sketch = np.array([-1, 0])
+    estimator = FirstMomentEstimator(method='uniform')
+    self.assertTrue(math.isnan(estimator([adbf])[0]))
+
   def test_denoise_and_union(self):
     noiser = BlipNoiser(
         epsilon=math.log(3), random_state=np.random.RandomState(5))

--- a/src/evaluations/data/evaluation_configs.py
+++ b/src/evaluations/data/evaluation_configs.py
@@ -907,7 +907,7 @@ def _independent_set_estimator(sketch_epsilon=None, estimate_epsilon=None):
   )
 
 
-def _hll_plus(estimate_epsilon=None):
+def _hll_plus():
   """Generate a SketchEstimatorConfig for HyperLogLogPlus.
 
   Args:
@@ -917,24 +917,16 @@ def _hll_plus(estimate_epsilon=None):
   Returns:
     A SketchEstimatorConfig for HyperLogLogPlus.
   """
-  if estimate_epsilon:
-    estimate_noiser = estimator_noisers.GeometricEstimateNoiser(
-        epsilon=estimate_epsilon)
-  else:
-    estimate_noiser = None
-
   sketch_len = 2**14
 
   return SketchEstimatorConfig(
       name=construct_sketch_estimator_config_name(
           sketch_name='hyper_log_log_plus',
           sketch_config=str(sketch_len),
-          estimator_name='hll_cardinality',
-          estimate_epsilon=estimate_epsilon),
+          estimator_name='hll_cardinality'),
       sketch_factory=hyper_log_log.HyperLogLogPlusPlus.get_sketch_factory(
           length=sketch_len),
       estimator=hyper_log_log.HllCardinality(),
-      estimate_noiser=estimate_noiser,
   )
 
 
@@ -1285,8 +1277,7 @@ def _generate_cardinality_estimator_configs():
                                                 estimate_epsilon))
 
   # Configs of hyper-log-log-plus.
-  for estimate_epsilon in ESTIMATE_EPSILON_VALUES:
-    configs.append(_hll_plus(estimate_epsilon))
+  configs.append(_hll_plus())
 
   # Configs of Meta VoC for Exp-ADBF.
   for voc_length in VOC_LENGTH_LIST:


### PR DESCRIPTION
This PR fix the bug in the test/interoperability_test.py by removing the un-used and buggy estimate noiser.

IMPORTANT: Please merge the `[Part X]Fix bug...` PR in the reverse order, as they are dependent. Eg, merge `[Part 3]Fix bug` into `[Part 2]Fix bug` first, then `[Part 2]Fix bug` into `[Part 1]Fix bug`.