### PR TITLE
[Part 3]Fix bug: Fix Uniform BF out of bound error.

### DIFF
--- a/src/estimators/bloom_filters.py
+++ b/src/estimators/bloom_filters.py
@@ -384,7 +384,9 @@ class FirstMomentEstimator(EstimatorBase):
     """Estimate cardinality of a Uniform Bloom Filter."""
     x = noiser(sum(sketch.sketch))
     m = len(sketch.sketch)
-    return - m * math.log(1 - x / m)
+    if x >= m or x < 0:
+      return float("NaN")
+    return -m * math.log(1 - x / m)
 
   @classmethod
   def _estimate_cardinality_log(cls, sketch, noiser):

--- a/src/estimators/tests/bloom_filters_test.py
+++ b/src/estimators/tests/bloom_filters_test.py
@@ -271,6 +271,17 @@ class FirstMomentEstimatorTest(parameterized.TestCase):
     estimate = estimator([adbf])[0]
     self.assertAlmostEqual(estimate, truth, 3, msg=method)
 
+  def test_uniform_bf_corner_cases(self):
+    adbf = UniformBloomFilter(length=2, random_seed=0)
+    # Test if the sketch is full.
+    adbf.sketch = np.array([1, 1])
+    estimator = FirstMomentEstimator(method='uniform')
+    self.assertTrue(math.isnan(estimator([adbf])[0]))
+    # Test if the register is negative.
+    adbf.sketch = np.array([-1, 0])
+    estimator = FirstMomentEstimator(method='uniform')
+    self.assertTrue(math.isnan(estimator([adbf])[0]))
+
   def test_denoise_and_union(self):
     noiser = BlipNoiser(
         epsilon=math.log(3), random_state=np.random.RandomState(5))


### PR DESCRIPTION
This PR fix the uniform BF estimator error when the sketch is full or the sum of registers is negative.

With this fix, we can run through the interoperability test for the meta VoC estimator for the BF. The root cause of this error is that the test has a small universe size, and the estimated number of active registers could have huge variance under the local DP theme. As such, the fake uniform BF could be full and throw errors. In the smoke test and the complete eval, we didn't observe this because the universe size is 200 and 1000 times larger than that of the interoperability test.

IMPORTANT: Please merge the [Part X]Fix bug... PR in the reverse order, as they are dependent. Eg, merge `[Part 3]Fix bug` into `[Part 2]Fix bug` first, then `[Part 2]Fix bug` into `[Part 1]Fix bug`.