### PR TITLE
Use tight Gaussian noise

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ scipy==1.2.1
 seaborn==0.9.0
 tqdm==4.47.0
 lxml==4.5.2
+dp-accounting==0.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ pathos==0.2.6
 pyfarmhash==0.2.2
 matplotlib==3.0.3
 numpy==1.16.4
+scipy==1.2.1
 seaborn==0.9.0
 tqdm==4.47.0
 lxml==4.5.2

--- a/src/common/noisers.py
+++ b/src/common/noisers.py
@@ -14,6 +14,8 @@
 
 import math
 import numpy as np
+from dp_accounting import accountant
+from dp_accounting import common
 
 
 class LaplaceMechanism:
@@ -142,10 +144,9 @@ class GaussianMechanism:
     """
     self._func = f
     self._delta_f = delta_f
-    # TODO(pasin30055): Use tight computation of sigma.
-    # Set the standard deviation sigma, following Appendix A of Dwork and Roth.
-    self._sigma = (math.sqrt(2 * math.log(1.25 / delta)) * delta_f *
-      math.sqrt(num_queries) / epsilon)
+    self._sigma = accountant.get_smallest_gaussian_noise(
+      common.DifferentialPrivacyParameters(epsilon, delta),
+      num_queries, sensitivity=delta_f)
     self._random_state = random_state or np.random.RandomState()
 
   def __call__(self, x):


### PR DESCRIPTION
This changes make the amount of Gaussian noise we add the smallest possible that still provides the given privacy level.
(The computation of the noise is done via the [dp-accounting](https://pypi.org/project/dp-accounting/) package.)