### PR TITLE
Add PolyaEstimateNoiser

### DIFF
--- a/src/estimators/estimator_noisers.py
+++ b/src/estimators/estimator_noisers.py
@@ -93,6 +93,29 @@ class GaussianEstimateNoiser(base.EstimateNoiserBase):
       return self._noiser(cardinality_estimate)
 
 
+class PolyaEstimateNoiser(base.EstimateNoiserBase):
+  """A noiser that adds a difference of two Polya noises to a cardinality estimate."""
+
+  def __init__(self, r, p, random_state=None):
+    """Instantiates a GaussianEstimateNoiser object.
+
+    Args:
+      r:  Parameter of the Polya distribution.
+      p:  Parameter of the Polya distribution.
+      random_state:  Optional instance of numpy.random.RandomState that is used
+        to seed the random number generator.
+    """
+    self._noiser = noisers.PolyaMechanism(
+      lambda x: x, r, p, random_state=random_state)
+
+  def __call__(self, cardinality_estimate):
+    """Returns a cardinality estimate with Gaussian noise."""
+    if type(cardinality_estimate) == float:
+      return self._noiser(np.array([cardinality_estimate]))[0]
+    else:
+      return self._noiser(cardinality_estimate)
+
+
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')

--- a/src/estimators/tests/estimator_noisers_test.py
+++ b/src/estimators/tests/estimator_noisers_test.py
@@ -34,6 +34,16 @@ class FakeGaussianRandomState:
   def normal(self, size, scale):
     return self.return_value
 
+class FakePolyaRandomState:
+
+  def __init__(self, return_values):
+    self.return_values = return_values
+    self.calls_count = 0
+
+  def negative_binomial(self, n, p, size):
+    self.calls_count += 1
+    return self.return_values[self.calls_count - 1]
+
 
 class EstimatorNoisersTest(absltest.TestCase):
 
@@ -72,6 +82,18 @@ class EstimatorNoisersTest(absltest.TestCase):
         1., .1, random_state=FakeGaussianRandomState([0.5, -0.5]))
     result = le(np.array([10., 20.]))
     np.testing.assert_array_equal(result, [10.5, 19.5])
+
+  def test_polya_estimate_noiser_accepts_scalar_argument(self):
+    le = estimator_noisers.PolyaEstimateNoiser(
+        .5, .1, random_state=FakePolyaRandomState([[4.], [3.]]))
+    result = le(10.)
+    self.assertEqual(result, 11)
+
+  def test_polya_estimate_noiser_accepts_array_argument(self):
+    le = estimator_noisers.PolyaEstimateNoiser(
+        .5, .1, random_state=FakePolyaRandomState([[3., -2.], [2., -1.]]))
+    result = le(np.array([10., 20.]))
+    np.testing.assert_array_equal(result, [11, 19])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add  PolyaMechanism and PolyaEstimateNoiser for adding a difference of two Polya noises to the input.

Note that, since we never use Polya alone (and hence there is no formal privacy proofs for the mechanism by itself), the initialization is done through the Polya parameters, rather than the privacy parameters.