### PR TITLE
Add Discrete Gaussian Noiser

### DIFF
--- a/src/common/noisers.py
+++ b/src/common/noisers.py
@@ -153,6 +153,78 @@ class GaussianMechanism:
     z = self._func(x)
     return z + self._random_state.normal(size=z.shape, scale=self._sigma)
 
+class DiscreteGaussianMechanism:
+  """Transforms a function using the discrete gaussian mechanism.
+
+  If f(x) = (Z[1], Z[2], ..., Z[k]), then returns a function that computes
+  (Z'[1], Z'[2], ..., Z'[k]), where
+      Z'[i] = Z[i] + Y[i],
+      Y[i] ~ N_Z(x | sigma),
+  and N_Z(x | sigma) is given by the probability mass function defined on the
+  integers such that N_Z(x | sigma) is proportional to
+  exp(-0.5 x^2 / sigma^2) / (sigma * sqrt(2 * pi)) for all integers x.
+
+  See:
+
+  Clément L. Canonne, Gautam Kamath, Thomas Steinke. "The Discrete Gaussian for
+  Differential Privacy" Advances in Neural Information Processing Systems 33
+  (NeurIPS 2020).
+  """
+
+  def __init__(
+    self, f, delta_f, epsilon, delta, num_queries=1, random_state=None):
+    """Instantiates a discrete gaussian mechanism.
+
+    Args:
+      f: A function which takes as input a database and which returns as output
+        a numpy array.
+      delta_f: The sensitivity paramater, e.g., the maximum value by which the
+        function can change for two databases that differ by only one row.
+      epsilon: Differential privacy parameter.
+      delta: Differential privacy parameter.
+      num_queries: The number of queries for which the mechanism is used. Note
+        that the constructed mechanism will be (epsilon, delta)-differentially
+        private when answering (no more than) num_queries queries.
+      random_state:  Optional instance of numpy.random.RandomState that is
+        used to seed the random number generator.
+    """
+    self._func = f
+    self._delta_f = delta_f
+
+    # This is only an estimate parameter using the continuous Gaussian as a
+    # a proxy. It is known that the two parameters are almost the same for
+    # a large regime of parameter; see Figure 1 in Canonne et al.'s paper.
+    # TODO: add a more rigorous parameter calculation based on privacy loss
+    # distributions.
+    self._sigma = accountant.get_smallest_gaussian_noise(
+      common.DifferentialPrivacyParameters(epsilon, delta),
+      num_queries, sensitivity=delta_f)
+    
+    self._random_state = random_state or np.random.RandomState()
+
+  def __call__(self, x):
+
+    def sample_discrete_gaussian(*unused):
+      # Use rejection sampling of discrete Laplace distribution (Algorithm 3 in
+      # Canonne et al.) to sample a discrete Gaussian random variable.
+      t = math.floor(self._sigma) + 1
+
+      while True:
+        # Generate discrete laplace with parameter t
+        p_geometric = 1 - math.exp(-1/t)
+        y1 = self._random_state.geometric(p=p_geometric)
+        y2 = self._random_state.geometric(p=p_geometric)
+        y = y1 - y2
+
+        sigma_sq = self._sigma**2
+        p_bernoulli = math.exp(-(abs(y) - sigma_sq/t)**2 * 0.5 / sigma_sq)
+        if self._random_state.binomial(1, p_bernoulli) == 1:
+          return y
+
+    z = self._func(x)
+    return z + np.fromfunction(
+      np.vectorize(sample_discrete_gaussian, otypes=[float]), z.shape)
+
 
 def main(argv):
   if len(argv) > 1:

--- a/src/estimators/estimator_noisers.py
+++ b/src/estimators/estimator_noisers.py
@@ -93,6 +93,34 @@ class GaussianEstimateNoiser(base.EstimateNoiserBase):
       return self._noiser(cardinality_estimate)
 
 
+class DiscreteGaussianEstimateNoiser(base.EstimateNoiserBase):
+  """A noiser that adds discrete Gaussian noise to a cardinality estimate."""
+
+  def __init__(self, epsilon, delta, num_queries=1, random_state=None):
+    """Instantiates a DiscreteGaussianEstimateNoiser object.
+
+    Args:
+      epsilon:  The differential privacy level.
+      delta:  The differential privacy level.
+      num_queries: The number of queries for which the noiser is used. Note
+        that the constructed noiser will be (epsilon, delta)-differentially
+        private when answering (no more than) num_queries queries.
+      random_state:  Optional instance of numpy.random.RandomState that is used
+        to seed the random number generator.
+    """
+    # Note that any cardinality estimator will have sensitivity (delta_f) of 1.
+    self._noiser = noisers.DiscreteGaussianMechanism(
+      lambda x: x, 1.0, epsilon, delta, num_queries=num_queries,
+      random_state=random_state)
+
+  def __call__(self, cardinality_estimate):
+    """Returns a cardinality estimate with Gaussian noise."""
+    if type(cardinality_estimate) == float:
+      return self._noiser(np.array([cardinality_estimate]))[0]
+    else:
+      return self._noiser(cardinality_estimate)
+
+
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')

--- a/src/estimators/tests/estimator_noisers_test.py
+++ b/src/estimators/tests/estimator_noisers_test.py
@@ -26,6 +26,7 @@ class FakeGeometricRandomState:
     self.calls_count += 1
     return self.return_values[self.calls_count - 1]
 
+
 class FakeGaussianRandomState:
 
   def __init__(self, return_value):
@@ -33,6 +34,23 @@ class FakeGaussianRandomState:
 
   def normal(self, size, scale):
     return self.return_value
+
+
+class FakeDiscreteGaussianRandomState:
+
+  def __init__(self, return_values_geometric, return_values_binomial):
+    self.return_values_geometric = return_values_geometric
+    self.return_values_binomial = return_values_binomial
+    self.calls_count_geometric = 0
+    self.calls_count_binomial = 0
+
+  def geometric(self, p):
+    self.calls_count_geometric += 1
+    return self.return_values_geometric[self.calls_count_geometric - 1]
+
+  def binomial(self, n, p):
+    self.calls_count_binomial += 1
+    return self.return_values_binomial[self.calls_count_binomial - 1]
 
 
 class EstimatorNoisersTest(absltest.TestCase):
@@ -72,6 +90,19 @@ class EstimatorNoisersTest(absltest.TestCase):
         1., .1, random_state=FakeGaussianRandomState([0.5, -0.5]))
     result = le(np.array([10., 20.]))
     np.testing.assert_array_equal(result, [10.5, 19.5])
+
+  def test_discrete_gaussian_estimate_noiser_accepts_scalar_argument(self):
+    le = estimator_noisers.DiscreteGaussianEstimateNoiser(
+        1., .1, random_state=FakeDiscreteGaussianRandomState([1.5, 1.], [1]))
+    result = le(10.)
+    self.assertEqual(result, 10.5)
+
+  def test_discrete_gaussian_estimate_noiser_accepts_array_argument(self):
+    le = estimator_noisers.DiscreteGaussianEstimateNoiser(
+        1., .1, random_state=FakeDiscreteGaussianRandomState(
+          [1.5, 1., -10., -30., 15., 13.7], [1, 0, 1]))
+    result = le(np.array([10., 20.]))
+    np.testing.assert_array_equal(result, [10.5, 21.3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add discrete gaussian mechanism and corresponding noiser. The algorithm is defined in [Canonne et al.'s paper](https://proceedings.neurips.cc/paper/2020/hash/b53b3a3d6ab90ce0268229151c9bde11-Abstract.html).

Currently there is one TODO on the noise computation; we have to wait for the PLD change to be opensourced first.