### PR TITLE
Update noiser for SKA

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-absl-py==0.9.0
-pathos==0.2.6
+absl-py==0.12.0
+pathos==0.2.7
 pyfarmhash==0.2.2
 matplotlib==3.0.3
-numpy==1.16.4
-scipy==1.2.1
+numpy==1.20.2
+scipy==1.6.2
 seaborn==0.9.0
 tqdm==4.47.0
 lxml==4.5.2


### PR DESCRIPTION
1. Update requirements.txt. The numpy version in the original file was outdated and caused bug.
2. Update noiser in StandardizedHistogramEstimator. Make it compatible with Gaussian and Discrete Gaussian noises.