### PR TITLE
Refactor StandardizedHistogramEstimator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
-absl-py==0.9.0
-pathos==0.2.6
+absl-py==0.12.0
+pathos==0.2.7
 pyfarmhash==0.2.2
 matplotlib==3.0.3
-numpy==1.16.4
-scipy==1.2.1
+numpy==1.20.2
+scipy==1.6.2
 seaborn==0.9.0
 tqdm==4.47.0
 lxml==4.5.2

--- a/src/estimators/same_key_aggregator.py
+++ b/src/estimators/same_key_aggregator.py
@@ -210,8 +210,8 @@ class StandardizedHistogramEstimator(EstimatorBase):
     Different entries of this list will be later composed, say, using advanced
     composition theorem.
     """
-    return [(self.reach_epsilon, self.reach_delta),
-            (self.frequency_epsilon, self.frequency_delta)]
+    return [(self.reach_noise_class, self.reach_epsilon, self.reach_delta),
+            (self.frequency_noise_class, self.frequency_epsilon, self.frequency_delta)]
 
   def get_per_bucket_epsilon_delta(self):
     """Get per bucket DP parameters from the given DP for the whole histogram.
@@ -224,8 +224,8 @@ class StandardizedHistogramEstimator(EstimatorBase):
     Returns:
       (epsilon, delta) for per-bucket noise.
     """
-    #TODO(jiayu): find tighter bound and eventually let the estimator do the
-    #accounting job
+    # TODO(jiayu): find tighter bound and eventually let the estimator do the
+    # accounting job
     return self.frequency_epsilon / 2, self.frequency_delta / 2
 
   @classmethod

--- a/src/estimators/tests/same_key_aggregator_test.py
+++ b/src/estimators/tests/same_key_aggregator_test.py
@@ -161,17 +161,17 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
 
   def test_define_noiser(self):
     rs = np.random.RandomState(1)
-    noiser, epsilon, delta = StandardizedHistogramEstimator.define_noiser(
+    noiser, ignore_delta = StandardizedHistogramEstimator.define_noiser(
         noiser_class=GeometricEstimateNoiser, epsilon=1,
         kwargs={'random_state': rs})
-    res = (noiser(0.), epsilon, delta)
-    expected = (-1., 1, 0)
+    res = (noiser(0.), ignore_delta)
+    expected = (-1., False)
     np.testing.assert_equal(res, expected)
-    noiser, epsilon, delta = StandardizedHistogramEstimator.define_noiser(
+    noiser, ignore_delta = StandardizedHistogramEstimator.define_noiser(
         noiser_class=GeometricEstimateNoiser, epsilon=1, delta=1e-5,
         kwargs={'random_state': rs})
-    res = (noiser(0.), epsilon, delta)
-    expected = (0., 1, 0)
+    res = (noiser(0.), ignore_delta)
+    expected = (0., True)
     np.testing.assert_equal(res, expected)
     # TODO(pasin) update GaussianEstimator & DiscreteGuassian
     # TODO(jiayu) complete testing for GaussianEstimator & DiscreteGuassian.
@@ -195,7 +195,7 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
     estimator = StandardizedHistogramEstimator(
         max_freq=6, reach_noiser_class=GeometricEstimateNoiser,
         frequency_noiser_class=GeometricEstimateNoiser,
-        reach_epsilon=0.5, frequency_epsilon=0.5,
+        reach_epsilon=1, frequency_epsilon=1,
         reach_noiser_kwargs={'random_state': np.random.RandomState(1)},
         frequency_noiser_kwargs={'random_state': np.random.RandomState(2)})
     res = estimator([first_ska, second_ska, third_ska])

--- a/src/estimators/tests/same_key_aggregator_test.py
+++ b/src/estimators/tests/same_key_aggregator_test.py
@@ -137,7 +137,7 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
     ska = ExponentialSameKeyAggregator(
         length=4, decay_rate=1, random_seed=0)
     ska.add_ids([0, 1, 2, 3])
-    estimator = StandardizedHistogramEstimator(noiser_class=None)
+    estimator = StandardizedHistogramEstimator()
     cardinality = estimator.estimate_one_plus_reach(ska)
     expected_cardinality = 5.877
     self.assertAlmostEqual(cardinality, expected_cardinality, delta=0.001)
@@ -146,8 +146,7 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
     ska = ExponentialSameKeyAggregator(
         length=4, decay_rate=1, random_seed=0)
     ska.add_ids([0, 1, 1, 1, 1, 2, 2, 3, 6, 6])
-    estimator = StandardizedHistogramEstimator(
-        max_freq=5, noiser_class=None)
+    estimator = StandardizedHistogramEstimator(max_freq=5)
     freq_hist = estimator.estimate_histogram_from_effective_keys(ska)
     expected_freq_hist = np.array([0, 2, 0, 1, 0])
     np.testing.assert_equal(freq_hist, expected_freq_hist)
@@ -160,6 +159,23 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
     expected = np.array([2, 2, 10, 6, 0])
     np.testing.assert_equal(res, expected)
 
+  def test_define_noiser(self):
+    rs = np.random.RandomState(1)
+    noiser, epsilon, delta = StandardizedHistogramEstimator.define_noiser(
+        noiser_class=GeometricEstimateNoiser, epsilon=1,
+        kwargs={'random_state': rs})
+    res = (noiser(0.), epsilon, delta)
+    expected = (-1., 1, 0)
+    np.testing.assert_equal(res, expected)
+    noiser, epsilon, delta = StandardizedHistogramEstimator.define_noiser(
+        noiser_class=GeometricEstimateNoiser, epsilon=1, delta=1e-5,
+        kwargs={'random_state': rs})
+    res = (noiser(0.), epsilon, delta)
+    expected = (0., 1, 0)
+    np.testing.assert_equal(res, expected)
+    # TODO(pasin) update GaussianEstimator & DiscreteGuassian
+    # TODO(jiayu) complete testing for GaussianEstimator & DiscreteGuassian.
+
   def test_end_to_end_estimator(self):
     first_ska = ExponentialSameKeyAggregator(
         length=4, decay_rate=1, random_seed=0)
@@ -170,31 +186,24 @@ class StandardizedHistogramEstimatorTest(absltest.TestCase):
     third_ska = ExponentialSameKeyAggregator(
         length=4, decay_rate=1, random_seed=0)
     third_ska.add_ids([1, 1, 4, 4])
-    estimator = StandardizedHistogramEstimator(
-        max_freq=6, noiser_class=None)
+    estimator = StandardizedHistogramEstimator(max_freq=6)
     res = estimator([first_ska, second_ska, third_ska])
     expected = [5.877, 2.939, 2.939, 2.939, 2.939, 0]
     np.testing.assert_almost_equal(res, expected, decimal=3,
                                    err_msg='Error in the unnoised case.')
+
     estimator = StandardizedHistogramEstimator(
-        max_freq=6, noiser_class=GeometricEstimateNoiser,
-        epsilon=1, epsilon_split=0.5,
-        reach_noiser_para={'random_state': np.random.RandomState(1)},
-        frequency_noiser_para={'random_state': np.random.RandomState(2)})
+        max_freq=6, reach_noiser_class=GeometricEstimateNoiser,
+        frequency_noiser_class=GeometricEstimateNoiser,
+        reach_epsilon=0.5, frequency_epsilon=0.5,
+        reach_noiser_kwargs={'random_state': np.random.RandomState(1)},
+        frequency_noiser_kwargs={'random_state': np.random.RandomState(2)})
     res = estimator([first_ska, second_ska, third_ska])
     expected = [2.854, 0.951, 1.903, 0.951, 0, -0.951]
     np.testing.assert_almost_equal(res, expected, decimal=3,
                                    err_msg='Error for geometric noise.')
-    estimator = StandardizedHistogramEstimator(
-        max_freq=6, noiser_class=GaussianEstimateNoiser,
-        epsilon=1, epsilon_split=0.5,
-        reach_noiser_para={'delta': 1e-5,
-                           'random_state': np.random.RandomState(1)},
-        frequency_noiser_para={'delta': 1e-5,
-                               'random_state': np.random.RandomState(2)})
-    res = estimator([first_ska, second_ska, third_ska])
     # TODO(pasin) update GaussianEstimator & DiscreteGuassian
-    # TODO(jiayu) complete testing.
+    # TODO(jiayu) complete testing for GaussianEstimator & DiscreteGuassian.
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Update StandardizedHistogramEstimator to (i) include the delta parameter (ii) support privacy budget tracking (iii) add more tests.

Will add more tests once Pasin updates Gaussian and DiscreteGaussian noisers. 

@matthewclegg I'm trying to support privacy budget tracking here, but not sure if my code design is reasonable.

@pasin30055 FYI of what we're doing. No need to carefully review it at this moment. An open question here is: how to composite the privacy budget for both reach and frequency estimation? You have result for discrete Laplacian noises in our paper, but how about Gaussian noises? We can discuss more in Tuesday's meeting.