### PR TITLE
Handle the corner case with zero or negative histogram

### DIFF
--- a/src/estimators/same_key_aggregator.py
+++ b/src/estimators/same_key_aggregator.py
@@ -307,6 +307,11 @@ class StandardizedHistogramEstimator(EstimatorBase):
   @classmethod
   def standardize_histogram(cls, histogram, total):
     """Scales a histogram (array) so that it sums up to a given total."""
+    if sum(histogram) <= 0:
+      warnings.warn("Zero or negative histogram. Try larger cardinality or "
+                    "adjust LiquidLegion params to increase the rate of "
+                    "active registers")
+      return np.zeros(len(histogram))
     return histogram / sum(histogram) * total
 
   def estimate_cardinality(self, exponential_same_key_aggregator):


### PR DESCRIPTION
In SameKeyAggregator, if sum(histogram) = 0 (for example, when there is no active register), an error will occur and block the rest of the planning evaluation. The PR gets around this corner case.